### PR TITLE
Shutdown gradually if not able to initialize display

### DIFF
--- a/src/drm.c
+++ b/src/drm.c
@@ -539,7 +539,7 @@ int modeset_prepare(int fd, struct modeset_output *output_list, uint16_t mode_wi
 
 		*output_list = *out;
 	}
-	if (!output_list) {
+	if (!out) {
 		fprintf(stderr, "couldn't create any outputs\n");
 		return -1;
 	}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -679,7 +679,11 @@ int main(int argc, char **argv)
 	assert(drm_fd >= 0);
 	output_list = (struct modeset_output *)malloc(sizeof(struct modeset_output));
 	ret = modeset_prepare(drm_fd, output_list, mode_width, mode_height, mode_vrefresh);
-	assert(!ret);
+	if (ret) {
+        fprintf(stderr,
+                "cannot initialize display. Is display connected? Is --screen-mode correct?\n");
+		return -2;
+    }
 	
 	////////////////////////////////// MPI SETUP
 	MppPacket packet;


### PR DESCRIPTION
There was a bug in the display initialization code that caused SIGSEGV on attempt to render something (video or OSD) on the screen when either screen is not connected or or resolution is not set correctly.

This PR makes sure pixelpilot detects the initialization error earlier and shuts down gradually.

Before:

```
#
# OSD, no video, no display
#
(gdb) run
Starting program: /usr/local/bin/pixelpilot --osd --osd-elements video,wfbng --screen-mode 1280x720@60
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/aarch64-linux-gnu/libthread_db.so.1".
PixelPilot Rockchip 0.10
ignoring unused connector 111
[New Thread 0xfffff552dfa0 (LWP 933)]
[New Thread 0xfffff4d2cfa0 (LWP 934)]
[New Thread 0xfffff452bfa0 (LWP 935)]
Changed prio for FRAME_THREAD to SCHED_FIFO:40
[New Thread 0xffffebffefa0 (LWP 936)]
[New Thread 0xfffff3d2afa0 (LWP 937)]
Starting mavlink thread...
[New Thread 0xfffff3529fa0 (LWP 938)]
/home/radxa/PixelPilot_rk/src/drm.c:126:28: runtime error: member access within null pointer of type 'struct drmModeObjectProperties'

Thread 7 "pixelpilot" received signal SIGSEGV, Segmentation fault.
[Switching to Thread 0xfffff3529fa0 (LWP 938)]
0x0000aaaaaaac16a4 in set_drm_object_property (req=0x0, obj=0xaaaaaab5c6d0, name=0xaaaaaaaebe40 "CRTC_ID", value=0) at /home/radxa/PixelPilot_rk/src/drm.c:126
126             for (i = 0; i < obj->props->count_props; i++) {
(gdb) where
#0  0x0000aaaaaaac16a4 in set_drm_object_property (req=0x0, obj=0xaaaaaab5c6d0, name=0xaaaaaaaebe40 "CRTC_ID", value=0) at /home/radxa/PixelPilot_rk/src/drm.c:126
#1  0x0000aaaaaaac6340 in modeset_atomic_prepare_commit (fd=11, out=0xaaaaaab5c6d0, req=0x0, plane=0xaaaaaab5c7c0, fb_id=0, width=0, height=0, zpos=2) at /home/radxa/PixelPilot_rk/src/drm.c:582
#2  0x0000aaaaaaac603c in modeset_perform_modeset (fd=11, out=0xaaaaaab5c6d0, req=0x0, plane=0xaaaaaab5c7c0, fb_id=0, width=0, height=0, zpos=2) at /home/radxa/PixelPilot_rk/src/drm.c:555
#3  0x0000aaaaaaaca118 in __OSD_THREAD__ (param=0xaaaaaab214c0) at /home/radxa/PixelPilot_rk/src/osd.c:317
#4  0x0000fffff7cb8648 in start_thread (arg=0xfffff35298a0) at pthread_create.c:477
#5  0x0000fffff6b30c9c in thread_start () at ../sysdeps/unix/sysv/linux/aarch64/clone.S:78

```

After this PR:

```
(gdb) run                                                                                             
Starting program: /usr/local/bin/pixelpilot --screen-mode 1280x720@60                                                                                                                                        
[Thread debugging using libthread_db enabled]                                                         
Using host libthread_db library "/lib/aarch64-linux-gnu/libthread_db.so.1".                                                                                                                                  
PixelPilot Rockchip 0.10                                                                                                                                                                                     
ignoring unused connector 111                                                                                                                                                                                
couldn't create any outputs                                                                           
cannot initialize display. Is display connected? Is --screen-mode correct?                                                                                                                                   
[Inferior 1 (process 837) exited with code 0377]                                                      
(gdb) q   
```