### PR TITLE
Refactor display detection

### DIFF
--- a/src/drm.h
+++ b/src/drm.h
@@ -106,7 +106,7 @@ void modeset_output_destroy(int fd, struct modeset_output *out);
 
 struct modeset_output *modeset_output_create(int fd, drmModeRes *res, drmModeConnector *conn, uint16_t mode_width, uint16_t mode_height, uint32_t mode_vrefresh);
 
-int modeset_prepare(int fd, struct modeset_output *output_list, uint16_t mode_width, uint16_t mode_height, uint32_t mode_vrefresh);
+struct modeset_output *modeset_prepare(int fd, uint16_t mode_width, uint16_t mode_height, uint32_t mode_vrefresh);
 
 int modeset_perform_modeset(int fd, struct modeset_output *out, drmModeAtomicReq * req, struct drm_object *plane, int fb_id, uint32_t width, uint32_t height, int zpos);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -683,13 +683,12 @@ int main(int argc, char **argv)
 		printf("modeset_open() =  %d\n", ret);
 	}
 	assert(drm_fd >= 0);
-	output_list = (struct modeset_output *)malloc(sizeof(struct modeset_output));
-	ret = modeset_prepare(drm_fd, output_list, mode_width, mode_height, mode_vrefresh);
-	if (ret) {
-        fprintf(stderr,
-                "cannot initialize display. Is display connected? Is --screen-mode correct?\n");
+	output_list = modeset_prepare(drm_fd, mode_width, mode_height, mode_vrefresh);
+	if (!output_list) {
+		fprintf(stderr,
+				"cannot initialize display. Is display connected? Is --screen-mode correct?\n");
 		return -2;
-    }
+	}
 	
 	////////////////////////////////// MPI SETUP
 	MppPacket packet;


### PR DESCRIPTION
* choose the first detected display, not the last one when multiple HDMI
* fix minor memory leak

Should address this issue https://github.com/OpenIPC/PixelPilot_rk/commit/e070b646af6b948c462f5287a58d03fe98f89989#commitcomment-147839951

Also fixes minor memory leak.