### PR TITLE
Publish a new release build on new tag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - master
+    tags:
+      - '*'
   pull_request:
     branches:
       - master
@@ -72,7 +74,13 @@ jobs:
           sudo chroot $output /home/run.sh --version
           sudo cp $output/home/build/pixelpilot .
 
-      - name: Upload
+      - name: Versioned release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: pixelpilot
+
+      - name: Upload latest
         if: github.event_name != 'pull_request'
         uses: softprops/action-gh-release@v2
         with:

--- a/README.md
+++ b/README.md
@@ -102,4 +102,4 @@ Pixelpilot starts several threads:
 * update project version in `CMakeList.txt`, `project(pixelpilot, VERSION <X.Y.Z>)`, commit
 * push that commit to master (either directly or with PR)
 * tag the tip of the master branch with the same `<X.Y.Z>` version
-* run `git push --tags`
+* run `git push --tags`; it will publish a new GitHub release


### PR DESCRIPTION
The way it works right now by patching the `latest` is somewhat non conventional. Let's create a tagged/versioned releases instead.