### PR TITLE
Add command line option to print the list of supported screen modes

### DIFF
--- a/src/drm.h
+++ b/src/drm.h
@@ -108,7 +108,7 @@ struct modeset_output *modeset_output_create(int fd, drmModeRes *res, drmModeCon
 
 struct modeset_output *modeset_prepare(int fd, uint16_t mode_width, uint16_t mode_height, uint32_t mode_vrefresh);
 
-void *modeset_print_modes(int fd, int verbosity);
+void *modeset_print_modes(int fd);
 
 int modeset_perform_modeset(int fd, struct modeset_output *out, drmModeAtomicReq * req, struct drm_object *plane, int fb_id, uint32_t width, uint32_t height, int zpos);
 

--- a/src/drm.h
+++ b/src/drm.h
@@ -108,6 +108,8 @@ struct modeset_output *modeset_output_create(int fd, drmModeRes *res, drmModeCon
 
 struct modeset_output *modeset_prepare(int fd, uint16_t mode_width, uint16_t mode_height, uint32_t mode_vrefresh);
 
+void *modeset_print_modes(int fd, int verbosity);
+
 int modeset_perform_modeset(int fd, struct modeset_output *out, drmModeAtomicReq * req, struct drm_object *plane, int fb_id, uint32_t width, uint32_t height, int zpos);
 
 int modeset_atomic_prepare_commit(int fd, struct modeset_output *out, drmModeAtomicReq *req, struct drm_object *plane, int fb_id, uint32_t width, uint32_t height, int zpos);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -492,8 +492,7 @@ void printHelp() {
     "\n"
     "    --screen-mode <mode>   - Override default screen mode. <width>x<heigth>@<fps> ex: 1920x1080@120\n"
     "\n"
-    "    --screen-mode-list <v> - Print the list of connected monitors and supported screen modes and exit.\n"
-    "                             Argument is the verbosity level: 1 - basic, 2 - verbose. See man drm-kms.\n"
+    "    --screen-mode-list     - Print the list of supported screen modes and exit.\n"
     "\n"
     "    --version              - Show program version\n"
     "\n", APP_VERSION_MAJOR, APP_VERSION_MINOR
@@ -510,7 +509,6 @@ int main(int argc, char **argv)
 	int mavlink_thread = 0;
 	int dvr_autostart = 0;
 	int print_modelist = 0;
-	int print_modelist_verbosity = 0;
 	char* dvr_template = NULL;
 	int video_framerate = -1;
 	int mp4_fragmentation_mode = 0;
@@ -626,7 +624,6 @@ int main(int argc, char **argv)
 	}
 
 	__OnArgument("--screen-mode-list") {
-		print_modelist_verbosity = atoi(__ArgValue);
 		print_modelist = 1;
 		continue;
 	}
@@ -663,7 +660,7 @@ int main(int argc, char **argv)
 	}
 	assert(drm_fd >= 0);
 	if (print_modelist) {
-		modeset_print_modes(drm_fd, print_modelist_verbosity);
+		modeset_print_modes(drm_fd);
 		close(drm_fd);
 		return 0;
 	}


### PR DESCRIPTION
Provides both "basic" and "verbose" modes.

On my monitor:

```
$ sudo pixelpilot --screen-mode-list 1
PixelPilot Rockchip 1.1
1920x1080@60
1920x1080@60
1920x1080@60
1920x1080@60
1920x1080@60
1920x1080@60
1920x1080@50
1920x1080@50
1920x1080@30
1920x1080@30
1920x1080@25
1920x1080@24
1920x1080@24
1600x1200@60
1680x1050@60
1280x1024@75
1280x1024@60
1152x864@75
...
```

```
$ sudo pixelpilot --screen-mode-list 2                                                                                                                                                    
PixelPilot Rockchip 1.1                                                                                                                                                                                      
connector id:111,width_mm:600,height_mm:340
mode name:1920x1080,pixel_clock:148352,hdisplay:1920,hsync_start:2008,hsync_end:2052,htotal:2200,hskew:0,vdisplay:1080,vsync_start:1084,vsync_end:1089,vtotal:1125,vscan:0,vrefresh:60,flags:PHSYNC|PVSYNC,type:PREFERRED|DRIVER                                                                                                                                                                                          
mode name:1920x1080,pixel_clock:148500,hdisplay:1920,hsync_start:2008,hsync_end:2052,htotal:2200,hskew:0,vdisplay:1080,vsync_start:1082,vsync_end:1087,vtotal:1125,vscan:0,vrefresh:60,flags:PHSYNC|PVSYNC,type:DRIVER                                                                                                                                                                                                    
mode name:1920x1080,pixel_clock:148500,hdisplay:1920,hsync_start:2008,hsync_end:2052,htotal:2200,hskew:0,vdisplay:1080,vsync_start:1084,vsync_end:1089,vtotal:1125,vscan:0,vrefresh:60,flags:PHSYNC|PVSYNC,type:DRIVER                                                                                                                                                                                                    
mode name:1920x1080i,pixel_clock:74250,hdisplay:1920,hsync_start:2008,hsync_end:2052,htotal:2200,hskew:0,vdisplay:1080,vsync_start:1084,vsync_end:1094,vtotal:1125,vscan:0,vrefresh:60,flags:PHSYNC|PVSYNC|INTERLACE,type:DRIVER
mode name:1920x1080i,pixel_clock:74250,hdisplay:1920,hsync_start:2008,hsync_end:2052,htotal:2200,hskew:0,vdisplay:1080,vsync_start:1084,vsync_end:1094,vtotal:1125,vscan:0,vrefresh:60,flags:PHSYNC|PVSYNC|INTERLACE,type:DRIVER
mode name:1920x1080i,pixel_clock:74176,hdisplay:1920,hsync_start:2008,hsync_end:2052,htotal:2200,hskew:0,vdisplay:1080,vsync_start:1084,vsync_end:1094,vtotal:1125,vscan:0,vrefresh:60,flags:PHSYNC|PVSYNC|INTERLACE,type:DRIVER                                                                                                                                                                                          
mode name:1920x1080,pixel_clock:148500,hdisplay:1920,hsync_start:2448,hsync_end:2492,htotal:2640,hskew:0,vdisplay:1080,vsync_start:1084,vsync_end:1089,vtotal:1125,vscan:0,vrefresh:50,flags:PHSYNC|PVSYNC,type:DRIVER                                                                                                                                                                                                    
mode name:1920x1080i,pixel_clock:74250,hdisplay:1920,hsync_start:2448,hsync_end:2492,htotal:2640,hskew:0,vdisplay:1080,vsync_start:1084,vsync_end:1094,vtotal:1125,vscan:0,vrefresh:50,flags:PHSYNC|PVSYNC|INTERLACE,type:DRIVER  
mode name:1920x1080,pixel_clock:74250,hdisplay:1920,hsync_start:2008,hsync_end:2052,htotal:2200,hskew:0,vdisplay:1080,vsync_start:1084,vsync_end:1089,vtotal:1125,vscan:0,vrefresh:30,flags:PHSYNC|PVSYNC,type:DRIVER
mode name:1920x1080,pixel_clock:74176,hdisplay:1920,hsync_start:2008,hsync_end:2052,htotal:2200,hskew:0,vdisplay:1080,vsync_start:1084,vsync_end:1089,vtotal:1125,vscan:0,vrefresh:30,flags:PHSYNC|PVSYNC,type:DRIVER
mode name:1920x1080,pixel_clock:74250,hdisplay:1920,hsync_start:2448,hsync_end:2492,htotal:2640,hskew:0,vdisplay:1080,vsync_start:1084,vsync_end:1089,vtotal:1125,vscan:0,vrefresh:25,flags:PHSYNC|PVSYNC,type:DRIVER
mode name:1920x1080,pixel_clock:74250,hdisplay:1920,hsync_start:2558,hsync_end:2602,htotal:2750,hskew:0,vdisplay:1080,vsync_start:1084,vsync_end:1089,vtotal:1125,vscan:0,vrefresh:24,flags:PHSYNC|PVSYNC,type:DRIVER
mode name:1920x1080,pixel_clock:74176,hdisplay:1920,hsync_start:2558,hsync_end:2602,htotal:2750,hskew:0,vdisplay:1080,vsync_start:1084,vsync_end:1089,vtotal:1125,vscan:0,vrefresh:24,flags:PHSYNC|PVSYNC,type:DRIVER
mode name:1600x1200,pixel_clock:162000,hdisplay:1600,hsync_start:1664,hsync_end:1856,htotal:2160,hskew:0,vdisplay:1200,vsync_start:1201,vsync_end:1204,vtotal:1250,vscan:0,vrefresh:60,flags:PHSYNC|PVSYNC,type:DRIVER
...
```

On my Walksnail X goggles:

```
$ sudo pixelpilot --screen-mode-list 2
PixelPilot Rockchip 1.1
connector id:111,width_mm:0,height_mm:0
mode name:1280x720,pixel_clock:74250,hdisplay:1280,hsync_start:1390,hsync_end:1430,htotal:1650,hskew:0,vdisplay:720,vsync_start:725,vsync_end:730,vtotal:750,vscan:0,vrefresh:60,flags:PHSYNC|PVSYNC,type:PREFERRED
mode name:1920x1080,pixel_clock:148500,hdisplay:1920,hsync_start:2008,hsync_end:2052,htotal:2200,hskew:0,vdisplay:1080,vsync_start:1084,vsync_end:1089,vtotal:1125,vscan:0,vrefresh:60,flags:PHSYNC|PVSYNC,type:DRIVER
mode name:1920x1080,pixel_clock:148500,hdisplay:1920,hsync_start:2448,hsync_end:2492,htotal:2640,hskew:0,vdisplay:1080,vsync_start:1084,vsync_end:1089,vtotal:1125,vscan:0,vrefresh:50,flags:PHSYNC|PVSYNC,type:DRIVER
mode name:1280x720,pixel_clock:74250,hdisplay:1280,hsync_start:1720,hsync_end:1760,htotal:1980,hskew:0,vdisplay:720,vsync_start:725,vsync_end:730,vtotal:750,vscan:0,vrefresh:50,flags:PHSYNC|PVSYNC,type:DRIVER
mode name:720x576,pixel_clock:27000,hdisplay:720,hsync_start:732,hsync_end:796,htotal:864,hskew:0,vdisplay:576,vsync_start:581,vsync_end:586,vtotal:625,vscan:0,vrefresh:50,flags:NHSYNC|NVSYNC,type:DRIVER
mode name:720x480,pixel_clock:27000,hdisplay:720,hsync_start:736,hsync_end:798,htotal:858,hskew:0,vdisplay:480,vsync_start:489,vsync_end:495,vtotal:525,vscan:0,vrefresh:60,flags:NHSYNC|NVSYNC,type:DRIVER
```

Is this output format ok?
The maning of the verbose output parameters is not 100% clear for me, it is briefly documented here https://www.kernel.org/doc/html/latest/gpu/drm-kms.html#c.drm_display_mode

Fixes #25.