### PR TITLE
add --osd-custom-message

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -484,7 +484,7 @@ void printHelp() {
     "\n"
     "    --osd-refresh <rate>   - Defines the delay between osd refresh (Default: 1000 ms)\n"
     "\n"
-    "    --osd-custom-message   - Enables the display of /run/pixelpilot.msg\n"
+    "    --osd-custom-message   - Enables the display of /run/pixelpilot.msg (beta feature, may be removed)\n"
     "\n"
     "    --dvr-template <path>  - Save the video feed (no osd) to the provided filename template.\n"
     "                             DVR is toggled by SIGUSR1 signal\n"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -80,6 +80,7 @@ pthread_cond_t video_cond;
 int video_zpos = 1;
 
 bool mavlink_dvr_on_arm = false;
+bool osd_custom_message = false;
 
 VideoCodec codec = VideoCodec::H265;
 Dvr *dvr = NULL;
@@ -483,6 +484,8 @@ void printHelp() {
     "\n"
     "    --osd-refresh <rate>   - Defines the delay between osd refresh (Default: 1000 ms)\n"
     "\n"
+    "    --osd-custom-message   - Enables the display of /run/pixelpilot.msg\n"
+    "\n"
     "    --dvr-template <path>  - Save the video feed (no osd) to the provided filename template.\n"
     "                             DVR is toggled by SIGUSR1 signal\n"
     "                             Supports placeholders %%Y - year, %%m - month, %%d - day,\n"
@@ -623,7 +626,12 @@ int main(int argc, char **argv)
 		osd_vars.telemetry_level = atoi(__ArgValue);
 		continue;
 	}
-	
+
+	__OnArgument("--osd-custom-message") {
+		osd_custom_message = true;
+		continue;
+	}
+
 	__OnArgument("--screen-mode") {
 		char* mode = const_cast<char*>(__ArgValue);
 		mode_width = atoi(strtok(mode, "x"));

--- a/src/osd.c
+++ b/src/osd.c
@@ -18,6 +18,9 @@ uint32_t stats_rx_bytes = 0;
 struct timespec last_timestamp = {0, 0};
 float rx_rate = 0;
 int hours = 0 , minutes = 0 , seconds = 0 , milliseconds = 0;
+char custom_msg[80];
+u_int custom_msg_refresh_count = 0;
+
 
 double getTimeInterval(struct timespec* timestamp, struct timespec* last_meansure_timestamp) {
   return (timestamp->tv_sec - last_meansure_timestamp->tv_sec) +
@@ -266,6 +269,47 @@ void modeset_paint_buffer(struct modeset_buf *buf) {
 	if(minutes > 59){
 		seconds = 0;
 		minutes = 0;
+	}
+
+	//display custom message
+	if (osd_custom_message) {
+		FILE *file = fopen("/run/pixelpilot.msg", "r");
+		if (file != NULL) {
+
+			if (fgets(custom_msg, sizeof(custom_msg), file) == NULL) {
+				perror("Error reading from file");
+				fclose(file);
+			}
+			fclose(file);
+			if (unlink("/run/pixelpilot.msg") != 0) {
+				perror("Error deleting the file");
+			}
+			custom_msg_refresh_count = 1;
+		}
+		if (custom_msg_refresh_count > 0) {
+
+			if (custom_msg_refresh_count++ > 5) custom_msg_refresh_count=0;
+
+			size_t msg_length = strlen(custom_msg);
+
+			//remove any trailing newline that fgets may read
+			if (msg_length > 0 && custom_msg[msg_length - 1] == '\n') {
+				custom_msg[msg_length - 1] = '\0';
+				msg_length--;  // Adjust length after removing newline
+			}
+
+			// Measure the text width
+			cairo_text_extents_t extents;
+			cairo_text_extents(cr, custom_msg, &extents);
+
+			// Calculate the position to center the text horizontally
+			double x = (buf->width / 2) - (extents.width / 2);
+			double y = (buf->height / 2);
+
+			// Set the position and draw the text
+			cairo_move_to(cr, x, y);
+			cairo_show_text(cr, custom_msg);
+		}
 	}
 
 	cairo_fill(cr);

--- a/src/osd.h
+++ b/src/osd.h
@@ -71,6 +71,7 @@ struct osd_vars {
 
 extern struct osd_vars osd_vars;
 extern int osd_thread_signal;
+extern bool osd_custom_message;
 extern pthread_mutex_t osd_mutex;
 
 typedef struct {


### PR DESCRIPTION
This MR will add the feature of a custom message displayed on screen.
pixelpilot will read from `/run/pixelpilot.msg` and display whatever is in there up to 79 chars.
After reading the input file will be deleted to make it ready for a new read.
Message will be displayed 4 osd refresh loops.

This makes it easy to quickly integrate other software.
As an example i currently use this to display the current channel when my channel switcher script is triggered via gpio.