### PR TITLE
Minor: assign thread name; fix compilation warnings

### DIFF
--- a/src/drm.h
+++ b/src/drm.h
@@ -7,7 +7,6 @@
 #ifndef DRM_H
 #define DRM_H
 
-#define _GNU_SOURCE
 #include <errno.h>
 #include <fcntl.h>
 #include <stdbool.h>

--- a/src/dvr.cpp
+++ b/src/dvr.cpp
@@ -1,4 +1,3 @@
-
 #include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -90,6 +89,7 @@ void Dvr::enqueue_dvr_command(dvr_rpc rpc) {
 }
 
 void *Dvr::__THREAD__(void *param) {
+	pthread_setname_np(pthread_self(), "__DVR");
 	((Dvr *)param)->loop();
 	return nullptr;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -183,6 +183,7 @@ void *__FRAME_THREAD__(void *param)
 	int i, ret;
 	MppFrame  frame  = NULL;
 	uint64_t last_frame_time;
+	pthread_setname_np(pthread_self(), "__FRAME");
 
 	while (!frm_eos) {
 		struct timespec ts, ats;
@@ -249,6 +250,8 @@ void *__DISPLAY_THREAD__(void *param)
 	float min_latency = 1844674407370955161; // almost MAX_uint64_t
 	float max_latency = 0;
     struct timespec fps_start, fps_end;
+
+	pthread_setname_np(pthread_self(), "__DISPLAY");
 	clock_gettime(CLOCK_MONOTONIC, &fps_start);
 
 	while (!frm_eos) {
@@ -379,7 +382,7 @@ void read_gstreamerpipe_stream(MppPacket *packet, int gst_udp_port, const VideoC
     GstRtpReceiver receiver(gst_udp_port, codec);
 	long long bytes_received = 0; 
 	uint64_t period_start=0;
-    auto cb=[&packet,&decoder_stalled_count, &bytes_received, &period_start](std::shared_ptr<std::vector<uint8_t>> frame){
+    auto cb=[&packet,/*&decoder_stalled_count,*/ &bytes_received, &period_start](std::shared_ptr<std::vector<uint8_t>> frame){
         // Let the gst pull thread run at quite high priority
         static bool first= false;
         if(first){

--- a/src/mavlink.c
+++ b/src/mavlink.c
@@ -1,3 +1,4 @@
+#define _GNU_SOURCE
 #include <sys/prctl.h>
 #include <errno.h>
 #include <fcntl.h>
@@ -9,6 +10,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include <pthread.h>
 
 #include <arpa/inet.h>
 #include <netinet/in.h>
@@ -83,6 +85,7 @@ int mavlink_port = 14550;
 int mavlink_thread_signal = 0;
 
 void* __MAVLINK_THREAD__(void* arg) {
+  pthread_setname_np(pthread_self(), "__MAVLINK");
   printf("Starting mavlink thread...\n");
   // Create socket
   int fd = socket(AF_INET, SOCK_DGRAM, 0);

--- a/src/osd.c
+++ b/src/osd.c
@@ -1,8 +1,9 @@
-
+#define _GNU_SOURCE
 #include "osd.h"
 
 #include "drm.h"
 #include <cairo.h>
+#include <pthread.h>
 #include "mavlink.h"
 #include "icons/icons.h"
 
@@ -303,6 +304,7 @@ cairo_surface_t * surface_from_embedded_png(const unsigned char * png, size_t le
 
 void *__OSD_THREAD__(void *param) {
 	osd_thread_params *p = param;
+	pthread_setname_np(pthread_self(), "__OSD");
 	fps_icon = surface_from_embedded_png(framerate_icon, framerate_icon_length);
 	lat_icon = surface_from_embedded_png(latency_icon, latency_icon_length);
 	net_icon = surface_from_embedded_png(bandwidth_icon, bandwidth_icon_length);


### PR DESCRIPTION
* Add threads names to make `gdb` a bit easier
* Don't capture static global variables into closures
* Keep _GNU_SOURCE in order