### PR TITLE
add ExternalSurfaceWidget

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ find_package(spdlog REQUIRED)
 find_package(nlohmann_json 3 REQUIRED)
 
 add_executable(${PROJECT_NAME} ${SOURCE_FILES})
-target_link_libraries(${PROJECT_NAME} rockchip_mpp pthread drm m cairo spdlog::spdlog nlohmann_json::nlohmann_json)
+target_link_libraries(${PROJECT_NAME} rockchip_mpp pthread drm m cairo spdlog::spdlog nlohmann_json::nlohmann_json rt)
 
 # Embed gstreamer
 find_package(PkgConfig REQUIRED)

--- a/config_osd.json
+++ b/config_osd.json
@@ -3,6 +3,13 @@
     "assets_dir": "/usr/local/share/pixelpilot/",
     "widgets": [
         {
+            "name": "msposd",
+            "type": "ExternalSurfaceWidget",
+            "x": 0,
+            "y": 0,
+            "facts": []
+        },
+        {
             "name": "WFB RSSI chart",
             "type": "BarChartWidget",
             "x": -320,

--- a/src/osd.hpp
+++ b/src/osd.hpp
@@ -14,6 +14,12 @@ typedef struct {
 
 extern int osd_thread_signal;
 
+struct SharedMemoryRegion {
+    uint16_t width;       // Image width
+    uint16_t height;      // Image height
+    unsigned char data[]; // Flexible array member for image data
+};
+
 void *__OSD_THREAD__(void *param);
 
 #endif


### PR DESCRIPTION
The PR adds an ExternalSurfaceWidget

The widget itself does not draw anything. It creates an empty cairo surface and exposes the memory region via shm.
The region can then be uses by a third party application to draw a custom OSD.

This is intended to be used by msposd and the new rockchip support. https://github.com/OpenIPC/msposd/pull/42
But this could be used by any other cairo capeable application.
Tested this with 2 exposed surfaces.