### PR TITLE
Fix osd flicker

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -292,7 +292,9 @@ void *__DISPLAY_THREAD__(void *param)
 		output_list->video_request = drmModeAtomicAlloc();
 
 		// show DRM FB in plane
+		uint32_t flags = DRM_MODE_ATOMIC_NONBLOCK;
 		if (fb_id != 0) {
+			flags = DRM_MODE_ATOMIC_ALLOW_MODESET;
 			ret = set_drm_object_property(output_list->video_request, &output_list->video_plane, "FB_ID", fb_id);
 			assert(ret>0);
 		}
@@ -303,7 +305,7 @@ void *__DISPLAY_THREAD__(void *param)
 			ret = set_drm_object_property(output_list->video_request, &output_list->osd_plane, "FB_ID", output_list->osd_bufs[output_list->osd_buf_switch].fb);
 			assert(ret>0);
 		}
-		drmModeAtomicCommit(drm_fd, output_list->video_request, DRM_MODE_ATOMIC_ALLOW_MODESET, NULL);
+		drmModeAtomicCommit(drm_fd, output_list->video_request, flags, NULL);
 		ret = pthread_mutex_unlock(&osd_mutex);
 		assert(!ret);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -281,7 +281,7 @@ void *__DISPLAY_THREAD__(void *param)
 		fb_id = output_list->video_fb_id;
 		osd_update = osd_update_ready;
 
-        uint64_t decoding_pts=output_list->decoding_pts;
+        uint64_t decoding_pts=fb_id != 0 ? output_list->decoding_pts : get_time_ms();
 		output_list->video_fb_id=0;
 		osd_update_ready = false;
 		ret = pthread_mutex_unlock(&video_mutex);


### PR DESCRIPTION
- This MR fixes the OSD flicker when no video is displayed.
- Additonally you can disable vsync using `--disable-vsync` or sending `kill -USR2 $(cat /run/pixelpilot.pid)` in flight

Fixes: https://github.com/OpenIPC/PixelPilot_rk/issues/29