### PR TITLE
Fix custom msg and config

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -701,7 +701,7 @@ int main(int argc, char **argv)
 	uint16_t mode_width = 0;
 	uint16_t mode_height = 0;
 	uint32_t mode_vrefresh = 0;
-	char * config_file_path;
+	char * config_file_path = NULL;
 	std::string osd_config_path;
 	auto log_level = spdlog::level::info;
 	


### PR DESCRIPTION
* add `unlink` for FIFO path before attempting to create a new one. It's because when pixelpilot exits abnormally, named pipe are going to persist
* make sure config file path is initialized as NULL
* custom message code is encasulated in C++ class instead of it being intermixed with the main loop