### PR TITLE
Fact converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Typical OSD config looks like:
 
 ```json
 {
-    "format": "0.0.1",
+    "format": "0.0.2",
     "assets_dir": "/usr/share/pixelpilot/",
     "widgets": [
         {
@@ -305,7 +305,7 @@ to display any fact (as long as datatype matches):
 * `{"type": "TextWidget", "text": "..."}` - displays a static string of text
 * `{"type": "TplTextWidget", "template": "..."}` - displays a string of text by replacing placeholders with
   the fact values. Supported placeholders are `%i` or `%d` - integer, `%b` - boolean, `%u` - unsigned,
-  `%s` - string, `%.f` / `%.0f` / `%.4f` - float with optional precision specifier
+  `%s` - string, `%f` / `%.0f` / `%.4f` - float with optional precision specifier
 * `{"type": "IconTplTextWidget", "template": "...", "icon_path": "foobar.png"}` - displays a
   graphical icon followed by templatized text string
 * `{"type": "BoxWidget", "width": 100, "height": 100, "color": {"r": 255, "g": 255, "b": 255, "alpha": 128}}` - displays

--- a/os_monitor_demo_osd.json
+++ b/os_monitor_demo_osd.json
@@ -1,5 +1,5 @@
 {
-    "format": "0.0.1",
+    "format": "0.0.2",
     "assets_dir": "/usr/share/pixelpilot/",
     "widgets": [
         {


### PR DESCRIPTION
There are two changes:

* now in template format string it's possible to specify the float precision, eg `Voltage: %.2fV` would result in `Voltage: 14.35V` while `Temperature: %.0fC` in `Temperature: 63C`
* now it's possible for any widget when you define that it is subscribed to a numeric fact, to specify a basic math conversion formula: `"convert": "x / 1000"` to adjust the original numeric value (a lot of metrics are collected in non-major units and it's more convinient to convert them to major before they are displayed. The math expression evaluator is maybe overengineered, but meh