### PR TITLE
Add battery cell voltage widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,12 @@ Specific widgets expect quite concrete facts as input:
   Uses `video.decode_and_handover_ms` fact
 * `GPSWidget` - displays GPS fix type (no fix / 2D fix / 3D fix etc) and GPS coordinates.
   Uses `mavlink.gps_raw.fix_type`, `mavlink.gps_raw.lat` and `mavlink.gps_raw.lon` facts
+* `{"type": "BatteryCellWidget", "template": "%.2fV", "critical_voltage": 3.5, "max_voltage": 4.2, "num_cells": "even"}` -
+  displays the individual cell voltage; the number of cells can be provided explicitly or auto-detected
+  from `max_voltage` and current pack voltage. Text changes color to yellow (20%) transitioning to
+  red (0%) when voltage approaches the `critical_voltage`. Change `critical_voltage` to ~3 for LiIon
+  and 3.5 for LiPo. This widget takes millivolts and is designed to work with `os_mon.power.voltage`,
+  but can probably be used with Mavlink as well.
 * `{"type": "IconSelectorWidget", "ranges_and_icons": [{"range": [0, 10], "icon_path": "0_10.png"}, {"range": [11, 20], ...}]}` - shows
   different icon depending on the range where the value lands to.
 

--- a/os_monitor_demo_osd.json
+++ b/os_monitor_demo_osd.json
@@ -46,6 +46,21 @@
                 {"name": "os_mon.power.power",
                  "convert": "x / 1000000"}
             ]
+        },
+        {
+            "type": "BatteryCellWidget",
+            "name": "Individual battery cell voltage",
+            "x": 350,
+            "y": 90,
+            "template": "(cell: %.2fV)",
+            "__comment1": "for LiPo set critical to 3.5; for LiIon critical to ~2.8-3",
+            "critical_voltage": 3.5,
+            "max_voltage": 4.2,
+            "__comment2": "num_cells can be 'auto' - to be autodetected, 'even' - autodetect even number (2/4/6/8..) or the actual number of cells eg 4 or 6 etc",
+            "num_cells": "even",
+            "facts": [
+                {"name": "os_mon.power.voltage"}
+            ]
         }
     ]
 }


### PR DESCRIPTION
This widget tries to estimate the number of LiIon/LiPo battery cells in the pack using the same way as betaflight:
https://github.com/betaflight/betaflight/blob/ad271cda7c1b7a06dc28c2cf3116bf5173246090/src/main/sensors/battery.c#L214

With an option to only detect even number of cells (2s / 4s / 6s are more common than 3s / 5s).

When cell level approaches critical level (configurable), it changes color to yellow and then to red.

It is designed to be used with `os_mon.power.voltage` (power supply of the ground station), but can in theory be used to show eg, battery level from the drone telemetry