### PR TITLE
Include last git commit date and hash in deb package version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,8 @@ qemu_build_deb:
 
 	sudo rm $(OUTPUT)/etc/resolv.conf
 	echo nameserver 1.1.1.1 | sudo tee -a $(OUTPUT)/etc/resolv.conf
-	LC_ALL=en_US.UTF-8 sudo chroot $(OUTPUT) /usr/src/PixelPilot_rk/tools/container_build.sh --wipe-boot --pkg-version $(DEB_VERSION) --debian-codename $(DEBIAN_CODENAME) --build-type deb
+	LC_ALL=C LC_CTYPE=C sudo chroot $(OUTPUT) /usr/src/PixelPilot_rk/tools/container_build.sh --wipe-boot \
+		--pkg-version $(shell git log --date=format:%Y%m%d --pretty='$(DEB_VERSION)~git%cd.%h' | head -n 1) --debian-codename $(DEBIAN_CODENAME) --build-type deb
 	make umount
 
 .PHONY: qemu_test

--- a/tools/container_build.sh
+++ b/tools/container_build.sh
@@ -113,7 +113,7 @@ case $BUILD_TYPE in
         apt-get install -y ./$BUILD_DEPS_FILE
         rm pixelpilot-rk-build-deps*
 
-        dpkg-buildpackage -uc -us -b
+        dpkg-buildpackage -uc -us
 
         #debuild -S -I
         ;;


### PR DESCRIPTION
It won't really work as-is, because debian/changelog should somehow include the new record with this `~git2025...`, otherwise DEB packages would be still generated with version from `changelog`.

One solution might be to add temporary record to changelog with `dch -v $pkg-version` with dummy content.