### PR TITLE
UI additions

### DIFF
--- a/gsmenu.sh
+++ b/gsmenu.sh
@@ -726,6 +726,9 @@ case "$@" in
     "values gs system rx_mode")
         echo -n -e "wfb\napfpv"
         ;;
+    "values gs system connector")
+        echo -n -e "HDMI"
+        ;;
     "values gs system resolution")
         drm_info -j /dev/dri/card0 2>/dev/null | jq -r '."/dev/dri/card0".connectors[1].modes[] | select(.name | contains("i") | not) | .name + "@" + (.vrefresh|tostring)' | sort | uniq  | sed -z '$ s/\n$//'
         ;;
@@ -738,6 +741,9 @@ case "$@" in
     ;;
     "get gs system gs_rendering")
         [ "$(grep ^render /config/setup.txt | cut -d ' ' -f 3)" = "ground" ] && echo 1 || echo 0
+        ;;
+    "get gs system connector")
+        echo HDMI
         ;;
     "get gs system resolution")
         drm_info -j /dev/dri/card0 2>/dev/null | jq -r '."/dev/dri/card0".crtcs[0].mode| .name + "@" + (.vrefresh|tostring)'
@@ -815,6 +821,9 @@ case "$@" in
             sed -i 's/^render =.*/render = ground/' /config/setup.txt
             msposd_rockchip --osd --ahi 0 --matrix 11 -v -r 5 --master 0.0.0.0:14551 &
         fi
+        ;;
+    "set gs system connector"*)
+        : # noop
         ;;
     "set gs system resolution"*)
         sed -i "s/^screen_mode =.*/screen_mode = $5/" /config/setup.txt

--- a/pixelpilot.yaml
+++ b/pixelpilot.yaml
@@ -30,7 +30,17 @@ gsmenu:
     # right: 32
     # up: 16
     # down: 18
-
+  # Define custom actions here
+  # action is the command the button will trigger
+  # actions:
+  #   air:
+  #     - label: Custom Action 1
+  #       action: sleep 5
+  #     - label: Custom Action 1
+  #       action: sleep 5
+  #   ground:
+  #     - label: Custom Action 1
+  #       action: sleep 5
 # enables collection of `os_mon.*` OSD facts
 os_sensors:
   cpu: true      # Monitor CPU load percentage

--- a/src/gsmenu/air_actions.c
+++ b/src/gsmenu/air_actions.c
@@ -6,9 +6,11 @@
 #include "helper.h"
 #include "executor.h"
 #include "styles.h"
+#include "air_actions.h"
 
 extern lv_group_t * default_group;
 lv_obj_t * air_reboot;
+lv_obj_t * air_custom_action;
 
 void create_air_actions_menu(lv_obj_t * parent) {
 
@@ -26,6 +28,11 @@ void create_air_actions_menu(lv_obj_t * parent) {
 
     air_reboot = create_button(section, "Reboot");
     lv_obj_add_event_cb(lv_obj_get_child_by_type(air_reboot,0,&lv_button_class),generic_button_callback,LV_EVENT_CLICKED,menu_page_data);
+
+    for (size_t i = 0; i < airactions_count; i++) {
+        air_custom_action = create_button(section, airactions[i].label);
+        lv_obj_add_event_cb(lv_obj_get_child_by_type(air_custom_action,0,&lv_button_class),custom_actions_cb,LV_EVENT_CLICKED,&airactions[i]);
+    }
 
     lv_group_set_default(default_group);
 }

--- a/src/gsmenu/air_actions.c
+++ b/src/gsmenu/air_actions.c
@@ -6,6 +6,7 @@
 #include "helper.h"
 #include "executor.h"
 #include "styles.h"
+#include "helper.h"
 #include "air_actions.h"
 
 extern lv_group_t * default_group;

--- a/src/gsmenu/air_actions.h
+++ b/src/gsmenu/air_actions.h
@@ -1,3 +1,7 @@
 #pragma once
+#include <stddef.h>
+#include "../menu.h"
+extern MenuAction airactions[MAX_ACTIONS];
+extern size_t airactions_count;
 
 void create_air_actions_menu(lv_obj_t * parent);

--- a/src/gsmenu/gs_actions.c
+++ b/src/gsmenu/gs_actions.c
@@ -7,6 +7,9 @@
 #include "helper.h"
 #include "executor.h"
 #include "styles.h"
+#include <stddef.h>
+#include "../menu.h"
+#include "gs_actions.h"
 
 #ifdef USE_SIMULATOR
 void sig_handler(int exit_code)
@@ -20,6 +23,7 @@ extern lv_group_t * default_group;
 lv_obj_t * restart_pp;
 lv_obj_t * exit_pp;
 lv_obj_t * gs_reboot;
+lv_obj_t * gs_custom_action;
 int restart_value = 1;
 int exit_value = 2;
 
@@ -50,6 +54,12 @@ void create_gs_actions_menu(lv_obj_t * parent) {
 
     gs_reboot = create_button(section, "Reboot");
     lv_obj_add_event_cb(lv_obj_get_child_by_type(gs_reboot,0,&lv_button_class),generic_button_callback,LV_EVENT_CLICKED,menu_page_data);
+
+
+    for (size_t i = 0; i < gsactions_count; i++) {
+        gs_custom_action = create_button(section, gsactions[i].label);
+        lv_obj_add_event_cb(lv_obj_get_child_by_type(gs_custom_action,0,&lv_button_class),custom_actions_cb,LV_EVENT_CLICKED,&gsactions[i]);
+    }
 
     lv_group_set_default(default_group);
 }

--- a/src/gsmenu/gs_actions.h
+++ b/src/gsmenu/gs_actions.h
@@ -1,3 +1,8 @@
 #pragma once
+#include <stddef.h>
+#include "../menu.h"
+
+extern MenuAction gsactions[MAX_ACTIONS];
+extern size_t gsactions_count;
 
 void create_gs_actions_menu(lv_obj_t * parent);

--- a/src/gsmenu/gs_system.c
+++ b/src/gsmenu/gs_system.c
@@ -13,6 +13,7 @@ enum RXMode RXMODE = WFB;
 
 lv_obj_t * rx_mode;
 lv_obj_t * gs_rendering;
+lv_obj_t * connector;
 lv_obj_t * resolution;
 lv_obj_t * rec_enabled;
 lv_obj_t * rec_fps;
@@ -36,6 +37,7 @@ void gs_system_page_load_callback(lv_obj_t * page)
     reload_switch_value(page,gs_rendering);
     reload_dropdown_value(page,rx_mode);
     RXMODE = lv_dropdown_get_selected(lv_obj_get_child_by_type(rx_mode,0,&lv_dropdown_class));
+    reload_dropdown_value(page,connector);
     reload_dropdown_value(page,resolution);
     reload_dropdown_value(page,rec_fps);
     reload_slider_value(page, video_scale);
@@ -138,6 +140,7 @@ void create_gs_system_menu(lv_obj_t * parent) {
     RXMODE = lv_dropdown_get_selected(lv_obj_get_child_by_type(rx_mode,0,&lv_dropdown_class));
 
     gs_rendering = create_switch(cont,LV_SYMBOL_SETTINGS,"GS Rendering","gs_rendering", menu_page_data,false);
+    connector = create_dropdown(cont,LV_SYMBOL_SETTINGS, "Connector","","connector",menu_page_data,false);
     resolution = create_dropdown(cont,LV_SYMBOL_SETTINGS, "Resolution","","resolution",menu_page_data,false);
     video_scale = create_slider(cont, LV_SYMBOL_SETTINGS, "Video scale factor", "video_scale", menu_page_data, false, 2);
 

--- a/src/gsmenu/helper.c
+++ b/src/gsmenu/helper.c
@@ -9,6 +9,7 @@
 #include "ui.h"
 #include "executor.h"
 #include "../WiFiRSSIMonitor.h"
+#include "../menu.h"
 
 extern enum RXMode RXMODE;
 
@@ -523,6 +524,7 @@ lv_obj_t * create_dropdown(lv_obj_t * parent, const char * icon, const char * la
     lv_dropdown_set_dir(dd, LV_DIR_RIGHT);
     lv_dropdown_set_symbol(dd, LV_SYMBOL_RIGHT);
     lv_obj_set_width(dd,300); // someone got a better idea ?
+    lv_obj_add_state(dd, LV_STATE_DISABLED);
 
     lv_obj_add_style(dd, &style_openipc_outline, LV_PART_MAIN | LV_STATE_FOCUS_KEY);
     lv_obj_add_style(dd, &style_openipc_dark_background, LV_PART_MAIN | LV_STATE_DEFAULT);
@@ -862,6 +864,8 @@ void get_dropdown_value(lv_obj_t * parent) {
     thread_data_t * param_user_data  = (thread_data_t*) lv_obj_get_user_data(obj);
     lv_dropdown_set_options(obj,get_values(param_user_data));
     update_dropdown_width(obj);
+    if (lv_dropdown_get_option_cnt(obj) > 1)
+        lv_obj_remove_state(obj, LV_STATE_DISABLED);
 }
 
 bool file_exists(const char *path) {
@@ -1007,4 +1011,10 @@ void delete_menu_page_entry_by_obj(menu_page_data_t *menu_page_data, lv_obj_t* o
         free(menu_page_data->page_entries);
         menu_page_data->page_entries = NULL;
     }
+}
+
+void custom_actions_cb(lv_event_t * event)
+{   
+    MenuAction *action = lv_event_get_user_data(event);
+    run_command_and_block(event, action->action, NULL);
 }

--- a/src/gsmenu/helper.c
+++ b/src/gsmenu/helper.c
@@ -524,7 +524,6 @@ lv_obj_t * create_dropdown(lv_obj_t * parent, const char * icon, const char * la
     lv_dropdown_set_dir(dd, LV_DIR_RIGHT);
     lv_dropdown_set_symbol(dd, LV_SYMBOL_RIGHT);
     lv_obj_set_width(dd,300); // someone got a better idea ?
-    lv_obj_add_state(dd, LV_STATE_DISABLED);
 
     lv_obj_add_style(dd, &style_openipc_outline, LV_PART_MAIN | LV_STATE_FOCUS_KEY);
     lv_obj_add_style(dd, &style_openipc_dark_background, LV_PART_MAIN | LV_STATE_DEFAULT);
@@ -864,8 +863,8 @@ void get_dropdown_value(lv_obj_t * parent) {
     thread_data_t * param_user_data  = (thread_data_t*) lv_obj_get_user_data(obj);
     lv_dropdown_set_options(obj,get_values(param_user_data));
     update_dropdown_width(obj);
-    if (lv_dropdown_get_option_cnt(obj) > 1)
-        lv_obj_remove_state(obj, LV_STATE_DISABLED);
+    if (lv_dropdown_get_option_cnt(obj) == 1)
+        lv_obj_add_flag(lv_obj_get_parent(obj), LV_OBJ_FLAG_HIDDEN);
 }
 
 bool file_exists(const char *path) {

--- a/src/gsmenu/helper.h
+++ b/src/gsmenu/helper.h
@@ -56,3 +56,4 @@ void gsmenu_toggle_rxmode();
 
 void add_entry_to_menu_page(menu_page_data_t *menu_page_data, const char* text, lv_obj_t* obj, ReloadFunc reload_func);
 void delete_menu_page_entry_by_obj(menu_page_data_t *menu_page_data, lv_obj_t* obj);
+void custom_actions_cb(lv_event_t * event);

--- a/src/menu.h
+++ b/src/menu.h
@@ -2,5 +2,15 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <stddef.h>
+
+#define MAX_ACTIONS 5
+#define MAX_LABEL_LEN 50
+#define MAX_ACTION_LEN 500
+
+typedef struct {
+    char label[MAX_LABEL_LEN];
+    char action[MAX_ACTION_LEN];
+} MenuAction;
 
 void pp_menu_main(void);


### PR DESCRIPTION
This PR add new gsmenu feature:

- Add the system option to select the connector for hardware that has more than a HDMI connector. Also tweaked the dropdown to be disabled when only one option is available. By default ony HDMI is presented, see gsmenu.sh
- Allow for customizable actions in air and ground menu. Configurable via pixelpilot.yaml