### PR TITLE
osd: parse custom message FIFO by newline and render multi-line popups

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -886,20 +886,55 @@ public:
         }
 
         // fd is non-blocking
-        char custom_msg[120];
-        osd_tag tags[1];
-        ssize_t bytes_read = read(fd, custom_msg, sizeof(custom_msg) - 1);
+        char chunk[120];
+        ssize_t bytes_read = read(fd, chunk, sizeof(chunk));
         if (bytes_read > 0) {
-            // If the last char is `\n`, then drop it
-            if (bytes_read > 1 && custom_msg[bytes_read - 1] == '\n') {
-                custom_msg[bytes_read - 1] = '\0';
-            } else {
-                custom_msg[bytes_read] = '\0';
-            }
-            strcpy(tags[0].key, "file");
-            strcpy(tags[0].val, fifoName);
-            osd_publish_str_fact("osd.custom_message", tags, 1, custom_msg);
+            buffer.append(chunk, bytes_read);
         }
+
+        // Emit one fact per `\n`-terminated message. If the buffer grows past
+        // MAX_MSG_LEN without a newline, flush it anyway so a stuck writer
+        // cannot make us grow unboundedly.
+        while (true) {
+            size_t nl = buffer.find('\n');
+            if (nl == std::string::npos) {
+                if (buffer.size() >= MAX_MSG_LEN) {
+                    publish_message(buffer);
+                    buffer.clear();
+                }
+                break;
+            }
+            std::string msg = buffer.substr(0, nl);
+            buffer.erase(0, nl + 1);
+            if (!msg.empty()) {
+                publish_message(msg);
+            }
+        }
+    }
+
+    // Unescape `\\n` -> literal newline so writers that cannot emit a raw
+    // newline (eg shell `echo` without `-e`) can still build multi-line
+    // messages.
+    static std::string unescape_newlines(const std::string& in) {
+        std::string out;
+        out.reserve(in.size());
+        for (size_t i = 0; i < in.size(); ++i) {
+            if (in[i] == '\\' && i + 1 < in.size() && in[i + 1] == 'n') {
+                out.push_back('\n');
+                ++i;
+            } else {
+                out.push_back(in[i]);
+            }
+        }
+        return out;
+    }
+
+    void publish_message(const std::string& raw) {
+        osd_tag tags[1];
+        strcpy(tags[0].key, "file");
+        strcpy(tags[0].val, fifoName);
+        std::string msg = unescape_newlines(raw);
+        osd_publish_str_fact("osd.custom_message", tags, 1, msg.c_str());
     }
 
     ~CustomMsgManager() {
@@ -910,9 +945,12 @@ public:
     }
 
 private:
+    static constexpr size_t MAX_MSG_LEN = 512;
+
     const char* fifoName;
     int fd; // File descriptor for the FIFO
     bool enabled;
+    std::string buffer; // accumulates partial reads until a `\n` is seen
 };
 
 void main_loop() {

--- a/src/osd.cpp
+++ b/src/osd.cpp
@@ -1172,23 +1172,59 @@ public:
 			auto past = std::chrono::duration_cast<std::chrono::milliseconds>(now - time);
 			double fade_fraction = 1.0 - static_cast<double>(past.count()) / static_cast<double>(timeout.count());
 
-			cairo_text_extents_t extents;
-			cairo_text_extents(cr, msg.c_str(), &extents);
+			// Cairo's `cairo_show_text` does not honour `\n`, so split the
+			// message on newlines and render each line on its own row.
+			std::vector<std::string> lines;
+			{
+				size_t start = 0;
+				while (start <= msg.size()) {
+					size_t nl = msg.find('\n', start);
+					if (nl == std::string::npos) {
+						lines.push_back(msg.substr(start));
+						break;
+					}
+					lines.push_back(msg.substr(start, nl - start));
+					start = nl + 1;
+				}
+			}
+
+			// Compute the bounding box for the whole multi-line message so
+			// the background sits behind every line.
+			double padding = 5.0;
+			double max_width = 0.0;
+			double total_height = 0.0;
+			double line_spacing = 2.0;
+			std::vector<cairo_text_extents_t> extents_per_line(lines.size());
+			for (size_t i = 0; i < lines.size(); ++i) {
+				cairo_text_extents(cr, lines[i].c_str(), &extents_per_line[i]);
+				if (extents_per_line[i].width > max_width) {
+					max_width = extents_per_line[i].width;
+				}
+				total_height += extents_per_line[i].height;
+				if (i + 1 < lines.size()) {
+					total_height += line_spacing;
+				}
+			}
 
 			// Draw popup box
-			double padding = 5.0;
 			cairo_set_source_rgba(cr, 0.0, 0.0, 0.0, fade_fraction / 3.0);
 			cairo_rectangle(cr,
 							x - padding,
 							y_offset + padding,
-							extents.width + (padding * 2), -(extents.height + (padding * 2)));
+							max_width + (padding * 2), -(total_height + (padding * 2)));
 			cairo_fill(cr);
 
-			// Draw popup text
+			// Draw popup text, line by line
 			cairo_set_source_rgba(cr, 255.0, 255.0, 255.0, fade_fraction);
-			cairo_move_to(cr, x, y_offset);
-			cairo_show_text(cr, msg.c_str());
-			y_offset += extents.height + (padding * 2) + 2;
+			uint line_y = y_offset;
+			for (size_t i = lines.size(); i-- > 0; ) {
+				cairo_move_to(cr, x, line_y);
+				cairo_show_text(cr, lines[i].c_str());
+				if (i > 0) {
+					line_y -= extents_per_line[i].height + line_spacing;
+				}
+			}
+			y_offset += total_height + (padding * 2) + 2;
 		}
 	}
 


### PR DESCRIPTION
Fixes #98.

`/run/pixelpilot.msg` was read once per second and whatever fit in a single non-blocking `read()` became one fact, so concurrent writers got glued together and a literal `\n` in the message rendered as a tofu square in the popup widget.

### Changes

**`src/main.cpp` — `CustomMsgManager`**

- Reads now accumulate into a `std::string` buffer instead of being published verbatim.
- Each `\n`-terminated chunk in the buffer is emitted as its own `osd.custom_message` fact, so multiple messages written during a single 1-second tick no longer collide.
- If a writer never sends a newline, the buffer is flushed once it reaches `MAX_MSG_LEN` (512 bytes) so we cannot grow unboundedly.
- Before publishing, the message is unescaped: a literal `\n` becomes a real newline. This lets writers that cannot emit raw newlines (e.g. plain `echo`, shell `printf` without `-e`, some scripting hosts) still produce multi-line messages.

**`src/osd.cpp` — `PopupWidget::draw`**

- The widget uses `cairo_show_text`, which doesn't honour `\n` — embedded newlines used to render as a tofu glyph. Each message is now split on `\n` and drawn as separate lines.
- The background box is sized to the longest line and the total stacked height, so the box still wraps the whole message rather than just the first line.

### Testing

- Verified the parser logic (escape unescape, buffer split across reads, multi-message split, escaped-newline -> split) locally with a small standalone harness.
- Did not run a full build on this host — the project cross-compiles for Rockchip ARM and requires `librockchip-mpp-dev`, `libdrm-dev`, etc., which I don't have set up locally. The changed code only uses `<string>` / `<vector>` and existing cairo calls that were already in the file, so it should compile on the target.

### Notes

- `MAX_MSG_LEN` is 512 (well above the previous 119-byte single-read cap, but small enough to stay safe). Happy to bump it if you'd prefer a different ceiling.
- The split-then-render approach in the popup keeps line spacing at 2 px, matching the existing inter-message spacing.