### PR TITLE
Majestic to Waybeam conversion

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,133 @@
+# PixelPilot_rk — Copilot Instructions
+
+## Current Branch: `majestic-to-waybeam`
+
+This branch converts the GStreamer pipeline source from **Majestic** (OpenIPC streamer) to **Waybeam**. The Waybeam video encoder API reference is at:
+```
+~/waybeam_venc_api_ref
+```
+Consult it when working with Waybeam encoder parameters, pipeline configuration, or any Waybeam-specific calls.
+
+## Project Overview
+
+WFB-ng video decoder and ground station display application for **Rockchip ARM64 platforms** (tested on RK3566/RK3588s). It uses Rockchip MPP for hardware-accelerated H.264/H.265 decoding, DRM/KMS for display, and Cairo/LVGL for the OSD. The real target hardware is an SBC running Debian Bullseye or Bookworm; there is a simulator mode for local development without hardware.
+
+## Build Commands
+
+All builds use CMake out-of-source in `build/`.
+
+**Production build (on Rockchip hardware):**
+```bash
+cmake -B build
+sudo cmake --build build --target install
+```
+
+**Debug build (enables ASAN + UBSAN, verbose spdlog):**
+```bash
+cmake -B build -DCMAKE_BUILD_TYPE=Debug
+cmake --build build
+```
+
+**Tests (Catch2, ARM64 only):**
+```bash
+cmake -B build -DBUILD_TESTS=ON
+cmake --build build
+./build/pixelpilot_tests                     # all tests
+./build/pixelpilot_tests "[ExpressionTree]"  # single test tag
+```
+
+**GSMenu simulator (local, no Rockchip hardware required):**
+```bash
+./sim.sh   # builds with -DUSE_SIMULATOR=ON and runs via SDL2
+```
+Simulator controls: `w/a/s/d/Enter` for navigation, `t` to toggle drone detection.
+
+**Cross-compile (QEMU on any x86 host):**
+```bash
+make qemu_build DEBIAN_CODENAME=bookworm     # binary
+make qemu_build_deb DEBIAN_CODENAME=bookworm # .deb package
+make qemu_test DEBIAN_CODENAME=bookworm      # run tests
+```
+Requires `qemu-user-static` installed. Downloads a Debian arm64 disk image.
+
+## Architecture
+
+### Threading model
+`src/main.cpp` is the orchestrator — it sets up DRM, spawns all threads, and tears them down on SIGTERM/SIGINT. Each subsystem runs as a dedicated pthread:
+
+| Thread function | Source | Purpose |
+|---|---|---|
+| `__OSD_THREAD__` | `src/osd.cpp` | Renders OSD via Cairo onto a DRM overlay plane |
+| `__WFB_CLI_THREAD__` | `src/wfbcli.cpp` | Polls wfb-ng statistics API and publishes Facts |
+| `FrameProcessor::__THREAD__` | `src/frame_processor.cpp` | Color-correct + OSD blend on GPU |
+| `FrameProcessor::__TIMER_THREAD__` | `src/frame_processor.cpp` | Paces frames to the DVR encoder at a steady FPS |
+| Mavlink thread | `src/mavlink.c` | Reads MAVLink UDP stream, publishes telemetry Facts |
+
+Thread functions follow the naming convention `__NAME_THREAD__` (uppercase with double underscores).
+
+### OSD / Facts pub-sub system
+The OSD (`src/osd.cpp`) is built around a **Facts** publish-subscribe pattern:
+
+- **Publishers** call `osd_publish_<type>()` / `osd_add_<type>()` (declared in `src/osd.h`) to emit named data points with optional string tags.
+- **Widgets** subscribe in JSON config by `"name"` and optional `"tags"` key-value pairs.
+- Fact types are strict: `int`, `uint`, `double`, `bool`, `string` — no implicit casting between them.
+- A `"convert"` expression on numeric facts (e.g. `"x / 1000"`) converts the value to `double` and appends `.converted` to the fact name.
+- New widget types must be implemented in C++ inside `src/osd.cpp`. The JSON config only parameterises existing widget types.
+
+OSD widgets render to a Cairo surface on a DRM plane separate from the video plane, managed by `src/drm.c`.
+
+### Video pipeline
+1. **GStreamer** (`src/gstrtpreceiver.cpp`) — receives RTP video over UDP/multicast.
+2. **Rockchip MPP decoder** — hardware-decoded frames (YUV420SP) arrive in `main.cpp`'s decoder loop.
+3. **FrameProcessor** (`src/frame_processor.cpp`) — receives decoded frames, optionally applies GPU color correction (EGL/GLES2 via `src/frame_colorcorrect.*` + `src/osd_gl.*`), blends OSD, then paces output to the DVR encoder.
+4. **MppEncoder** (`src/mpp_encoder.cpp`) — hardware re-encodes for DVR recording (`src/dvr.cpp`).
+5. **DRM/KMS** (`src/drm.c`) — final display; video on one plane, OSD on another.
+
+### GSMenu (LVGL on-screen menu)
+`src/gsmenu/` implements a hierarchical on-screen menu using LVGL. Structure:
+- `gs_main.c` — creates root menu; coordinates ground-station pages (`gs_*`)
+- `air_*` files — communicate with the air unit (camera, wfb-ng TX profiles, etc.)
+- `executor.c` — runs shell commands triggered by menu actions, with blocking/non-blocking variants
+- `ui.c` / `styles.c` — shared LVGL widget helpers and visual styles
+
+The simulator (`src/simulator.c`, `-DUSE_SIMULATOR`) builds only the GSMenu with SDL2 so it can be developed without Rockchip hardware.
+
+### Configuration files
+| File | Location | Purpose |
+|---|---|---|
+| `pixelpilot.yaml` | `/etc/pixelpilot/pixelpilot.yaml` | GPIO pin mapping, GSMenu enable, OS sensors, restream IP |
+| `config_osd.json` | `/etc/pixelpilot/config_osd.json` | OSD widget layout and fact subscriptions |
+| `lv_conf.h` | project root | LVGL compile-time configuration (not inside `lvgl/`) |
+
+## Key Conventions
+
+### Mixed C/C++ boundary
+Headers that are included from both C and C++ use `#pragma once`. C++ files that call into C APIs wrap the includes in `extern "C" { ... }`. Pure C files (e.g., `drm.c`, `mavlink.c`, `gsmenu/*.c`) are compiled as C99; the main application is C++17.
+
+### Test-only code exposure
+The `TEST` preprocessor macro (defined when `BUILD_TESTS=ON` via `target_compile_definitions`) gates test-accessor wrapper classes in `src/osd.hpp`:
+```cpp
+#ifdef TEST
+class TestExpressionTree { ... };
+class TestTplTextWidget  { ... };
+#endif
+```
+Tests in `tests/test_osd.cpp` use these wrappers to reach private internals.
+
+### Simulator guard
+`USE_SIMULATOR` is defined when building with `-DUSE_SIMULATOR=ON`. Code that requires real Rockchip hardware (MPP, DRM, RGA) must be guarded or excluded from simulator builds.
+
+### Negative OSD coordinates
+In `config_osd.json`, negative `x`/`y` values are relative to the right/bottom edge of the screen. This is a display-resolution-independent positioning system used throughout the OSD widget layout.
+
+### spdlog logging
+All logging uses `spdlog`. In `Debug` builds `SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_TRACE` is defined, enabling trace-level messages. Use the `spdlog::` API rather than `printf`/`fprintf` for any new logging.
+
+### Submodule
+`lvgl/` is a git submodule. Always run `git submodule update --init` after cloning or when `lvgl/` appears empty.
+
+### gsmenu.sh mirror
+`gsmenu.sh` in this repo is mirrored in the [sbc-groundstations](https://github.com/OpenIPC/sbc-groundstations) repository. Whenever `gsmenu.sh` is modified here, the same change must be applied to:
+```
+~/sbc-groundstations/package/pixelpilot/files/gsmenu.sh
+```

--- a/src/gsmenu/colmenu_pages.c
+++ b/src/gsmenu/colmenu_pages.c
@@ -291,25 +291,28 @@ static const colmenu_page_t air_aalink_page = { "AALink", "air", "aalink", air_a
 
 /* Camera sub-pages (all type=air page=camera) */
 static const colmenu_item_t cam_video_items[] = {
-    /* Size and FPS are WFB-specific; APFPV direct connection has fixed camera modes. */
-    { .kind=COLMENU_DROPDOWN, .label="Size",       .param="size",       .mode_mask=COLMENU_MODE_WFB },
+    /* WFB air units run Waybeam, which exposes a single fixed-mode selector
+     * instead of independent Size/FPS (those were Majestic-specific). APFPV
+     * direct connection still has its own fixed camera modes. */
+    { .kind=COLMENU_DROPDOWN, .label="Mode",       .param="mode",       .mode_mask=COLMENU_MODE_WFB },
     { .kind=COLMENU_DROPDOWN, .label="Video Mode", .param="video_mode", .mode_mask=COLMENU_MODE_APFPV },
-    { .kind=COLMENU_DROPDOWN, .label="FPS",        .param="fps",        .mode_mask=COLMENU_MODE_WFB },
     { .kind=COLMENU_DROPDOWN, .label="Bitrate",    .param="bitrate" },
-    { .kind=COLMENU_DROPDOWN, .label="Codec",      .param="codec" },
+    /* Codec dropdown dropped: the Waybeam/star6e encoder is H.265-only. */
     { .kind=COLMENU_SLIDER,   .label="Gopsize",    .param="gopsize" },
     { .kind=COLMENU_DROPDOWN, .label="RC Mode",    .param="rc_mode" },
 };
-static const colmenu_page_t cam_video_page = { "Video", "air", "camera", cam_video_items, 7 };
+static const colmenu_page_t cam_video_page = { "Video", "air", "camera", cam_video_items, 5 };
 static const colmenu_item_t cam_image_items[] = {
     { .kind=COLMENU_SWITCH, .label="Mirror",     .param="mirror" },
     { .kind=COLMENU_SWITCH, .label="Flip",       .param="flip" },
+    { .kind=COLMENU_SLIDER, .label="Lightness",  .param="lightness" },
     { .kind=COLMENU_SLIDER, .label="Contrast",   .param="contrast" },
-    { .kind=COLMENU_SLIDER, .label="Hue",        .param="hue" },
+    { .kind=COLMENU_SLIDER, .label="Brightness", .param="brightness" },
     { .kind=COLMENU_SLIDER, .label="Saturation", .param="saturation" },
-    { .kind=COLMENU_SLIDER, .label="Luminance",  .param="luminace" },
+    { .kind=COLMENU_SLIDER, .label="Sharpness",  .param="sharpness" },
+    { .kind=COLMENU_SLIDER, .label="HSV",        .param="hsv" },
 };
-static const colmenu_page_t cam_image_page = { "Image", "air", "camera", cam_image_items, 6 };
+static const colmenu_page_t cam_image_page = { "Image", "air", "camera", cam_image_items, 8 };
 static const colmenu_item_t cam_rec_items[] = {
     { .kind=COLMENU_SWITCH, .label="Enabled",  .param="rec_enable" },
     { .kind=COLMENU_SLIDER, .label="Split",    .param="rec_split" },
@@ -317,9 +320,9 @@ static const colmenu_item_t cam_rec_items[] = {
 };
 static const colmenu_page_t cam_rec_page = { "Recording", "air", "camera", cam_rec_items, 3 };
 static const colmenu_item_t cam_isp_items[] = {
-    { .kind=COLMENU_SLIDER,   .label="Exposure",    .param="exposure" },
-    { .kind=COLMENU_DROPDOWN, .label="Antiflicker", .param="antiflicker" },
-    { .kind=COLMENU_DROPDOWN, .label="Sensor File", .param="sensor_file" },
+    { .kind=COLMENU_SLIDER,   .label="EV Compensation", .param="exposure" },
+    { .kind=COLMENU_DROPDOWN, .label="Antiflicker",     .param="antiflicker" },
+    { .kind=COLMENU_DROPDOWN, .label="Sensor File",     .param="sensor_file" },
 };
 static const colmenu_page_t cam_isp_page = { "ISP", "air", "camera", cam_isp_items, 3 };
 static const colmenu_item_t cam_fpv_items[] = {


### PR DESCRIPTION
In this (draft) PR I compile a list of everything that needs to change to make PixelPilot compatible with **waybeam_venc** instead of Majestic, and track progress on the implementation.
If anything is missing, let me know and I'll add it to the list.

---

## Sensor / Mode

- [x] Replace separate Size, FPS, and Video Mode dropdowns with a single **Mode** dropdown backed by `GET /api/v1/modes`

## Recording

- [x] `get air camera rec_enable` — query recording state via `GET /api/v1/record/status`
- [x] `set air camera rec_enable` — start/stop via `GET /api/v1/record/start|stop` with retry-and-status-check loop (no Majestic CLI fallback)

## Infrastructure helpers (gsmenu.sh)

- [x] `waybeam_api_get(endpoint)` — base curl wrapper
- [x] `waybeam_record_active()` — checks `/record/status` for `"active": true`
- [x] `waybeam_record_start()` / `waybeam_record_stop()`
- [x] `waybeam_record_set_with_retry_bg(on|off)` — retry loop with status verification, background subshell
- [x] `waybeam_set_config(key, value)` — calls `/api/v1/set?key=value`; returns 1 and logs to stderr on failure
- [x] `waybeam_mode_options()` / `waybeam_mode_index_from_label()` — mode dropdown helpers
- [x] `waybeam_get_config(key)` — `GET /api/v1/get?key`, replaces `get_majestic_value()`
- [x] `waybeam_get_iq(param)` — query a single ISP IQ parameter from `GET /api/v1/iq`
- [x] `waybeam_set_iq(param, value)` — set a single ISP IQ parameter via `GET /api/v1/iq/set`
- [x] `waybeam_restart()` — `GET /api/v1/restart` (needed after setting RESTART-mutability fields)

## Image settings — get side

- [x] `get air camera mirror` → `GET /api/v1/get?image.mirror`
- [x] `get air camera flip` → `GET /api/v1/get?image.flip`
- [x] `get air camera contrast` → `GET /api/v1/iq` → `contrast` param
- [x] ~~`get air camera hue`~~ → renamed to `get air camera brightness` → `GET /api/v1/iq` → `brightness` param
- [x] `get air camera saturation` → `GET /api/v1/iq` → `saturation` param
- [x] ~~`get air camera luminace`~~ → renamed to `get air camera lightness` → `GET /api/v1/iq` → `lightness` param
- [x] `get air camera sharpness` *(new)* → `GET /api/v1/iq` → `sharpness` param
- [x] `get air camera hsv` *(new)* → `GET /api/v1/iq` → `hsv` param

## Image settings — set side

- [x] `set air camera mirror` → `GET /api/v1/set?image.mirror=` + restart
- [x] `set air camera flip` → `GET /api/v1/set?image.flip=` + restart
- [x] `set air camera contrast` → `GET /api/v1/iq/set?param=contrast&value=` (LIVE)
- [x] ~~`set air camera hue`~~ → renamed to `set air camera brightness` → `GET /api/v1/iq/set?param=brightness&value=` (LIVE)
- [x] `set air camera saturation` → `GET /api/v1/iq/set?param=saturation&value=` (LIVE)
- [x] ~~`set air camera luminace`~~ → renamed to `set air camera lightness` → `GET /api/v1/iq/set?param=lightness&value=` (LIVE)
- [x] `set air camera sharpness` *(new)* → `GET /api/v1/iq/set?param=sharpness&value=` (LIVE)
- [x] `set air camera hsv` *(new)* → `GET /api/v1/iq/set?param=hsv&value=` (LIVE)

## Video encoding — get side

- [x] `get air camera bitrate` → `GET /api/v1/get?video0.bitrate`
- [x] `get air camera gopsize` → `GET /api/v1/get?video0.gopSize`
- [x] `get air camera rc_mode` → `GET /api/v1/get?video0.rcMode` (added `qvbr` option)
- [x] `get air camera codec` → returns `h265` statically; control hidden in UI (Waybeam is H.265-only on star6e)

## Video encoding — set side

- [x] `set air camera bitrate` → `GET /api/v1/set?video0.bitrate=` (LIVE)
- [x] `set air camera gopsize` → `GET /api/v1/set?video0.gopSize=` (LIVE)
- [x] `set air camera rc_mode` → `GET /api/v1/set?video0.rcMode=` + restart
- [x] `set air camera codec` → no-op; control hidden in UI

## ISP / exposure — get side

- [x] `get air camera antiflicker` → `GET /api/v1/iq` → `ae_flicker` param
- [x] `get air camera exposure` → `GET /api/v1/iq` → `ae_ev_comp` (EV compensation, range -4 to 4); UI label renamed to "EV Compensation"
- [x] `get air camera sensor_file` → `GET /api/v1/get?isp.sensorBin`

## ISP / exposure — set side

- [x] `set air camera antiflicker` → `GET /api/v1/iq/set?param=ae_flicker&value=`
- [x] `set air camera exposure` → `GET /api/v1/iq/set?param=ae_ev_comp&value=` (LIVE)
- [x] `set air camera sensor_file` → `GET /api/v1/set?isp.sensorBin=` + restart

## FPV / ROI — get side

- [x] `get air camera fpv_enable` → `GET /api/v1/get?fpv.roiEnabled`
- [x] `get air camera noiselevel` → `GET /api/v1/get?fpv.noiseLevel` (range 0–7)

## FPV / ROI — set side

- [x] `set air camera fpv_enable` → `GET /api/v1/set?fpv.roiEnabled=` (LIVE)
- [x] `set air camera noiselevel` → `GET /api/v1/set?fpv.noiseLevel=` + restart

## Recording config (drone-side) — get side

- [x] `get air camera rec_split` → `GET /api/v1/get?record.maxSeconds` (range 0–300)
- [x] `get air camera rec_maxusage` → `GET /api/v1/get?record.maxMB` (range 0–10000)

## Recording config (drone-side) — set side

- [x] `set air camera rec_split` → `GET /api/v1/set?record.maxSeconds=` + restart
- [x] `set air camera rec_maxusage` → `GET /api/v1/set?record.maxMB=` + restart

## Additional fixes

- [x] `set air wfbng adaptivelink` — removed majestic CLI calls; uses `waybeam_set_config` for `video0.qpDelta`
- [x] `reload_switch_value` — fix callback double-fire bug (remove/re-add event cb around `lv_obj_set_state`)
- [x] `bitrate` visibility — no longer toggled by `gsmenu_toggle_rxmode`

## Infrastructure cleanup

- [x] Remove `get_majestic_value()` (all camera reads now use Waybeam API)
- [x] Remove `MAJESTIC_YAML` variable
- [x] Remove `majestic.yaml` from `refresh_cache()` SCP
- [x] `wfb.yaml` / `alink.conf` SCP cache retained — still needed for WFB-ng and alink settings

## Out of scope for this PR

- WFB-ng wireless settings (channel, MCS, STBC, LDPC, FEC) — controlled via `wifibroadcast cli`, not Majestic/waybeam
- Telemetry settings — controlled via `wifibroadcast cli`
- Alink drone feature — separate process, separate scope
