### PR TITLE
DVR reencode: stop silently corrupting recordings, fail fast instead

### DIFF
--- a/src/frame_colorcorrect.cpp
+++ b/src/frame_colorcorrect.cpp
@@ -194,12 +194,20 @@ bool FrameColorCorrect::create_targets() {
     for (int i = 0; i < kTargets; i++) {
         Target& t = targets_[i];
 
+        // This target is never scanned out via KMS -- it's an intermediate
+        // GPU render target that RGA reads back via wrapbuffer_fd_t(), which
+        // assumes a plain linear raster layout with no modifier awareness.
+        // GBM_BO_USE_SCANOUT hints the allocator toward a scanout-optimized
+        // (potentially tiled/compressed) layout; GBM_BO_USE_LINEAR forces the
+        // layout RGA actually expects.
         t.bo = gbm_bo_create(gbm_, width_, height_, GBM_FORMAT_ARGB8888,
-                             GBM_BO_USE_RENDERING | GBM_BO_USE_SCANOUT);
+                             GBM_BO_USE_RENDERING | GBM_BO_USE_LINEAR);
         if (!t.bo) {
             spdlog::error("FrameCC: gbm_bo_create failed for target {}", i);
             return false;
         }
+        spdlog::info("FrameCC: target {} bo stride={} modifier=0x{:x}", i,
+                     gbm_bo_get_stride(t.bo), gbm_bo_get_modifier(t.bo));
 
         // Export once; keep fd open for RGA use in process()
         t.prime_fd = gbm_bo_get_fd(t.bo);

--- a/src/frame_processor.cpp
+++ b/src/frame_processor.cpp
@@ -227,25 +227,30 @@ void FrameProcessor::process_loop() {
                 // 16-aligned, e.g. 1080p's 8 rows up to dst_vs) always hold
                 // sane content, by construction rather than by detection.
                 // A hardware probe confirmed this platform's dma-buf cache
-                // sync is a no-op for CPU reads of RGA-written memory (even
-                // with DMA_BUF_IOCTL_SYNC on the correct fd/mapping), so a
-                // "poison then check via CPU" guard is fundamentally unable
-                // to observe RGA's output here -- this instead extends the
-                // last real row(s) into the padding with one more RGA copy,
-                // entirely within the RGA/DMA domain, needing no CPU read of
-                // GPU/RGA-written memory at all.
+                // sync is a no-op for CPU reads of RGA/GPU-written memory
+                // (even with DMA_BUF_IOCTL_SYNC on the correct fd/mapping),
+                // so a "poison then check via CPU" guard can't observe RGA's
+                // output here -- but a plain CPU *write* is fine, since the
+                // encoder (a separate DMA consumer, reading afterward) has
+                // always reliably seen CPU-written content in this buffer
+                // (same primitives as the raw-copy fallback path, proven
+                // extensively earlier). Writing directly avoids needing any
+                // RGA call for this at all, so it's identical on every
+                // librga version/build target instead of depending on which
+                // im2d API happens to be available at compile time.
                 if (ok && dst_vs > dst_h) {
-                    uint32_t pad_h = dst_vs - dst_h;
-                    rga_buffer_t pad_buf = wrapbuffer_fd_t(
-                        mpp_buffer_get_fd(proc_copy_),
-                        dst_w, dst_h, dst_hs, dst_vs, RK_FORMAT_YCbCr_420_SP);
-                    rga_buffer_t pat = {};
-                    im_rect srect = {0, (int)(dst_h - pad_h), (int)dst_w, (int)pad_h};
-                    im_rect drect = {0, (int)dst_h,           (int)dst_w, (int)pad_h};
-                    im_rect prect = {};
-                    im_opt_t opt = {};
-                    if (improcess(pad_buf, pad_buf, pat, srect, drect, prect,
-                                  -1, nullptr, &opt, IM_SYNC) != IM_STATUS_SUCCESS) {
+                    uint8_t *base = (uint8_t *)mpp_buffer_get_ptr(proc_copy_);
+                    if (base) {
+                        // Y-plane padding rows [dst_h, dst_vs).
+                        memset(base + (size_t)dst_h * dst_hs, 128,
+                              (size_t)(dst_vs - dst_h) * dst_hs);
+                        // UV-plane padding rows [dst_h/2, dst_vs/2) -- U and V
+                        // are interleaved, so 128/128 (neutral chroma) is a
+                        // flat fill across the whole sub-region.
+                        size_t uv_off = (size_t)dst_hs * dst_vs;
+                        memset(base + uv_off + (size_t)(dst_h / 2) * dst_hs, 128,
+                              (size_t)(dst_vs / 2 - dst_h / 2) * dst_hs);
+                    } else {
                         spdlog::error("FrameProcessor: failed to cover output padding");
                         ok = false;
                     }

--- a/src/frame_processor.cpp
+++ b/src/frame_processor.cpp
@@ -223,6 +223,34 @@ void FrameProcessor::process_loop() {
                          : (imresize(src_rga, dst_rga) == IM_STATUS_SUCCESS);
                 }
 
+                // Guarantee the padding rows (present whenever dst_h isn't
+                // 16-aligned, e.g. 1080p's 8 rows up to dst_vs) always hold
+                // sane content, by construction rather than by detection.
+                // A hardware probe confirmed this platform's dma-buf cache
+                // sync is a no-op for CPU reads of RGA-written memory (even
+                // with DMA_BUF_IOCTL_SYNC on the correct fd/mapping), so a
+                // "poison then check via CPU" guard is fundamentally unable
+                // to observe RGA's output here -- this instead extends the
+                // last real row(s) into the padding with one more RGA copy,
+                // entirely within the RGA/DMA domain, needing no CPU read of
+                // GPU/RGA-written memory at all.
+                if (ok && dst_vs > dst_h) {
+                    uint32_t pad_h = dst_vs - dst_h;
+                    rga_buffer_t pad_buf = wrapbuffer_fd_t(
+                        mpp_buffer_get_fd(proc_copy_),
+                        dst_w, dst_h, dst_hs, dst_vs, RK_FORMAT_YCbCr_420_SP);
+                    rga_buffer_t pat = {};
+                    im_rect srect = {0, (int)(dst_h - pad_h), (int)dst_w, (int)pad_h};
+                    im_rect drect = {0, (int)dst_h,           (int)dst_w, (int)pad_h};
+                    im_rect prect = {};
+                    im_opt_t opt = {};
+                    if (improcess(pad_buf, pad_buf, pat, srect, drect, prect,
+                                  -1, nullptr, &opt, IM_SYNC) != IM_STATUS_SUCCESS) {
+                        spdlog::error("FrameProcessor: failed to cover output padding");
+                        ok = false;
+                    }
+                }
+
                 // Never publish a frame we can't be sure is fully and
                 // correctly written: a "successful-looking" recording that's
                 // actually corrupted (skipped colour-correction and/or a

--- a/src/frame_processor.cpp
+++ b/src/frame_processor.cpp
@@ -25,8 +25,10 @@ static inline uint32_t align_up(uint32_t v, uint32_t a) {
     return (v + a - 1) & ~(a - 1);
 }
 
-FrameProcessor::FrameProcessor(MppEncoder *enc, int fps, EncResolution res, int drm_fd)
-    : encoder(enc), interval_ns(1000000000L / fps), target_res_((int)res), drm_fd_(drm_fd) {
+FrameProcessor::FrameProcessor(MppEncoder *enc, int fps, EncResolution res, int drm_fd,
+                               std::function<void()> on_fatal_error)
+    : encoder(enc), interval_ns(1000000000L / fps), target_res_((int)res),
+      on_fatal_error_(std::move(on_fatal_error)), drm_fd_(drm_fd) {
     mpp_buffer_group_get_internal(&hold_grp, MPP_BUFFER_TYPE_DRM);
 }
 
@@ -34,7 +36,6 @@ FrameProcessor::~FrameProcessor() {
     shutdown();
     if (last_copy)   { mpp_buffer_put(last_copy);   last_copy   = nullptr; }
     if (proc_copy_)  { mpp_buffer_put(proc_copy_);  proc_copy_  = nullptr; }
-    if (blend_rgba_) { mpp_buffer_put(blend_rgba_); blend_rgba_ = nullptr; }
     if (hold_grp)    { mpp_buffer_group_put(hold_grp); hold_grp = nullptr; }
 }
 
@@ -128,8 +129,10 @@ void FrameProcessor::process_loop() {
         }
         if (!fresh.buffer) continue;
 
-        // If DVR is not active, just drain the frame to release the decoder ref.
-        if (!dvr_enabled || !encoder) {
+        // If DVR is not active, or a prior frame failed to convert and the
+        // reencode session hasn't been restarted since, just drain the
+        // frame to release the decoder ref.
+        if (!dvr_enabled || !encoder || reenc_fatal_.load(std::memory_order_relaxed)) {
             fresh.release();
             continue;
         }
@@ -145,6 +148,7 @@ void FrameProcessor::process_loop() {
 
         // ── Copy / resize / colour-correct / OSD blend ──────────────────
         // copy_mtx_ is held so drain_decoder_refs() can safely wait for us.
+        bool fatal = false;
         {
             std::lock_guard<std::mutex> copy_lock(copy_mtx_);
 
@@ -184,27 +188,28 @@ void FrameProcessor::process_loop() {
                     color_gl_.init(drm_fd_, dst_w, dst_h, cc_gain_, cc_offset_);
                 }
 
-                bool copied = false;
-                if (need_gl && color_gl_.ready()) {
-                    // Register current OSD buffer with the GL shader.
-                    if (osd_snap.prime_fd >= 0)
-                        color_gl_.set_osd(osd_snap.prime_fd,
-                                          osd_snap.width, osd_snap.height,
-                                          osd_snap.stride_px);
-                    else
-                        color_gl_.clear_osd();
-
+                bool ok;
+                if (need_gl) {
                     // GPU: NV12 → RGBA (shader: colorcorrect + OSD blend)
                     //      → NV12 (RGA CSC, no resize — GBM BO is at output size)
-                    copied = color_gl_.process(
-                        mpp_buffer_get_fd(fresh.buffer),
-                        fresh.width, fresh.height,
-                        fresh.hor_stride, fresh.ver_stride,
-                        mpp_buffer_get_fd(proc_copy_),
-                        dst_hs, dst_vs);
-                }
-                if (!copied) {
-                    // ── RGA fallback: resize/copy + RGA OSD blend ────────
+                    ok = color_gl_.ready();
+                    if (ok) {
+                        if (osd_snap.prime_fd >= 0)
+                            color_gl_.set_osd(osd_snap.prime_fd,
+                                              osd_snap.width, osd_snap.height,
+                                              osd_snap.stride_px);
+                        else
+                            color_gl_.clear_osd();
+
+                        ok = color_gl_.process(
+                            mpp_buffer_get_fd(fresh.buffer),
+                            fresh.width, fresh.height,
+                            fresh.hor_stride, fresh.ver_stride,
+                            mpp_buffer_get_fd(proc_copy_),
+                            dst_hs, dst_vs);
+                    }
+                } else {
+                    // Neither colour-correction nor OSD active: plain RGA copy/resize.
                     int rga_fmt = mpp_fmt_to_rga(fresh.fmt);
                     rga_buffer_t src_rga = wrapbuffer_fd_t(
                         mpp_buffer_get_fd(fresh.buffer),
@@ -213,57 +218,37 @@ void FrameProcessor::process_loop() {
                     rga_buffer_t dst_rga = wrapbuffer_fd_t(
                         mpp_buffer_get_fd(proc_copy_),
                         dst_w, dst_h, dst_hs, dst_vs, rga_fmt);
-                    if (fresh.width == dst_w && fresh.height == dst_h) {
-                        if (imcopy(src_rga, dst_rga) != IM_STATUS_SUCCESS) {
-                            size_t copy_sz = (size_t)fresh.hor_stride * fresh.ver_stride * 3 / 2;
-                            size_t actual = mpp_buffer_get_size(fresh.buffer);
-                            if (copy_sz > actual) copy_sz = actual;
-                            void *sp = mpp_buffer_get_ptr(fresh.buffer);
-                            void *dp = mpp_buffer_get_ptr(proc_copy_);
-                            if (sp && dp) memcpy(dp, sp, copy_sz);
-                        }
-                    } else {
-                        if (imresize(src_rga, dst_rga) != IM_STATUS_SUCCESS) {
-                            spdlog::warn("RGA resize failed {}x{} -> {}x{}",
-                                         fresh.width, fresh.height, dst_w, dst_h);
-                        }
-                    }
-
-                    // RGA OSD blend fallback (3 ops: NV12→BGRA, blend, BGRA→NV12)
-                    if (osd_snap.prime_fd >= 0 && osd_snap.width > 0 && osd_snap.height > 0) {
-                        size_t bgra_sz = (size_t)dst_hs * dst_vs * 4;
-                        if (!blend_rgba_ || mpp_buffer_get_size(blend_rgba_) < bgra_sz) {
-                            if (blend_rgba_) { mpp_buffer_put(blend_rgba_); blend_rgba_ = nullptr; }
-                            mpp_buffer_get(hold_grp, &blend_rgba_, bgra_sz);
-                        }
-                        if (blend_rgba_) {
-                            rga_buffer_t nv12 = wrapbuffer_fd_t(
-                                mpp_buffer_get_fd(proc_copy_),
-                                dst_w, dst_h, dst_hs, dst_vs,
-                                RK_FORMAT_YCbCr_420_SP);
-                            rga_buffer_t bgra = wrapbuffer_fd_t(
-                                mpp_buffer_get_fd(blend_rgba_),
-                                dst_w, dst_h, dst_hs, dst_vs,
-                                RK_FORMAT_BGRA_8888);
-                            rga_buffer_t osd_rga = wrapbuffer_fd_t(
-                                osd_snap.prime_fd,
-                                osd_snap.width, osd_snap.height,
-                                osd_snap.stride_px, osd_snap.height,
-                                RK_FORMAT_BGRA_8888);
-                            imcvtcolor(nv12, bgra, RK_FORMAT_YCbCr_420_SP, RK_FORMAT_BGRA_8888);
-                            imblend(osd_rga, bgra, IM_ALPHA_BLEND_SRC_OVER);
-                            imcvtcolor(bgra, nv12, RK_FORMAT_BGRA_8888, RK_FORMAT_YCbCr_420_SP);
-                        }
-                    }
+                    ok = (fresh.width == dst_w && fresh.height == dst_h)
+                         ? (imcopy(src_rga, dst_rga) == IM_STATUS_SUCCESS)
+                         : (imresize(src_rga, dst_rga) == IM_STATUS_SUCCESS);
                 }
-                proc_meta_.width      = dst_w;
-                proc_meta_.height     = dst_h;
-                proc_meta_.hor_stride = dst_hs;
-                proc_meta_.ver_stride = dst_vs;
-                proc_meta_.fmt        = fresh.fmt;
-                proc_meta_.buffer     = nullptr;
+
+                // Never publish a frame we can't be sure is fully and
+                // correctly written: a "successful-looking" recording that's
+                // actually corrupted (skipped colour-correction and/or a
+                // garbled image region -- confirmed reproducible via hardware
+                // fault injection) is worse than one that visibly stops, so
+                // any conversion failure ends the reencode session instead of
+                // degrading through a best-effort fallback.
+                if (!ok) {
+                    spdlog::error("FrameProcessor: frame conversion failed, stopping DVR reencode");
+                    fatal = true;
+                } else {
+                    proc_meta_.width      = dst_w;
+                    proc_meta_.height     = dst_h;
+                    proc_meta_.hor_stride = dst_hs;
+                    proc_meta_.ver_stride = dst_vs;
+                    proc_meta_.fmt        = fresh.fmt;
+                    proc_meta_.buffer     = nullptr;
+                }
             }
             fresh.release();  // decoder buffer is free again
+        }
+
+        if (fatal) {
+            reenc_fatal_.store(true, std::memory_order_relaxed);
+            if (on_fatal_error_) on_fatal_error_();
+            continue;
         }
 
         // ── Publish: swap proc buffer into last_copy for the timer ──────

--- a/src/frame_processor.h
+++ b/src/frame_processor.h
@@ -4,6 +4,7 @@
 #include <stdint.h>
 #include <atomic>
 #include <condition_variable>
+#include <functional>
 #include <mutex>
 
 #include <rockchip/rk_mpi.h>
@@ -40,9 +41,16 @@ struct FrameProcFrame {
 
 class FrameProcessor {
 public:
+    // on_fatal_error is invoked (from the processor thread) the first time a
+    // frame can't be reliably converted -- see process_loop() for why this
+    // stops the reencode session instead of degrading through a fallback.
     FrameProcessor(MppEncoder *enc, int fps, EncResolution res = EncResolution::Res1080p,
-                   int drm_fd = -1);
+                   int drm_fd = -1, std::function<void()> on_fatal_error = nullptr);
     ~FrameProcessor();
+
+    // Re-arm after a fatal conversion failure (call when reencode recording
+    // is (re)started, e.g. from Dvr::on_start_cb).
+    void clear_fatal_error() { reenc_fatal_.store(false, std::memory_order_relaxed); }
 
     // Called from decoder thread: update the latest available frame.
     void push_latest(MppBuffer buf, uint32_t w, uint32_t h,
@@ -88,6 +96,8 @@ private:
     std::atomic<long>     interval_ns;
     std::atomic<int>      target_res_{1};  // 0=720p, 1=1080p
     std::atomic<bool>     running{true};
+    std::atomic<bool>     reenc_fatal_{false};  // set once a frame conversion fails
+    std::function<void()> on_fatal_error_;      // invoked once when reenc_fatal_ is set
     std::mutex              mtx;       // guards pending (shared with frame/decoder thread)
     std::condition_variable cv_;       // signalled by push_latest(); processor waits here
     std::mutex              copy_mtx_; // held by processor while it uses a decoder buffer
@@ -103,7 +113,6 @@ private:
     // Only accessed from the processor thread — no mutex needed:
     MppBufferGroup    hold_grp  = nullptr;  // our own DRM buffer pool
     MppBuffer         proc_copy_  = nullptr;  // processor's working buffer
-    MppBuffer         blend_rgba_ = nullptr;  // BGRA intermediate for RGA OSD fallback
     FrameProcFrame     proc_meta_;              // metadata being built by processor
 
     // OSD blend — shared between OSD thread (writer) and processor thread (reader)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -16,6 +16,7 @@
 #include <inttypes.h>
 #include <signal.h>
 #include <fstream>
+#include <chrono>
 #include <atomic>
 #include <queue>
 #include <mutex>
@@ -36,6 +37,8 @@
 #include <nlohmann/json.hpp>
 #include <yaml-cpp/yaml.h>
 #include "spdlog/spdlog.h"
+#include "spdlog/sinks/stdout_color_sinks.h"
+#include "spdlog/sinks/rotating_file_sink.h"
 
 extern "C" {
 #include "main.h"
@@ -339,6 +342,28 @@ void *__FRAME_THREAD__(void *param)
 					}
 					idr_request_decoder_issue(reason);
 				}
+
+				// Track decoder error/discard rates over time: these are
+				// otherwise completely silent unless they escalate to an
+				// (independently rate-limited) IDR request, but a storm of
+				// them is exactly the "poor-link period" signal that has
+				// correlated with rare RGA/GPU frame-conversion hiccups
+				// downstream -- worth having in the log to line up against
+				// any later "frame conversion failed" error.
+				static uint64_t win_errinfo = 0, win_discard = 0, win_frames = 0;
+				static time_t win_start = 0;
+				win_frames++;
+				if (errinfo) win_errinfo++;
+				if (discard) win_discard++;
+				if (win_start == 0) win_start = ats.tv_sec;
+				if (ats.tv_sec - win_start >= 5) {
+					if (win_errinfo || win_discard) {
+						spdlog::warn("Decoder health: {} frames, errinfo={} discard={} in last {}s",
+						             win_frames, win_errinfo, win_discard, ats.tv_sec - win_start);
+					}
+					win_errinfo = win_discard = win_frames = 0;
+					win_start = ats.tv_sec;
+				}
 				if (!mpi.first_frame_ts.tv_sec) {
 					ts = ats;
 					mpi.first_frame_ts = ats;
@@ -505,12 +530,15 @@ void sigusr1_handler(int signum) {
 	bool was_enabled = dvr_enabled;
 	if (was_enabled) {
 		// Stopping
+		spdlog::info("DVR: stopping recording (SIGUSR1)");
 		if (dvr_raw) dvr_raw->stop_recording();
 		if (dvr_reenc_inst) dvr_reenc_inst->stop_recording();
 		dvr_enabled = 0;
 		osd_publish_bool_fact("dvr.recording", NULL, 0, false);
 	} else {
 		// Starting
+		spdlog::info("DVR: starting recording (SIGUSR1, mode={})",
+		             dvr_mode == DVR_MODE_RAW ? "raw" : dvr_mode == DVR_MODE_REENCODE ? "reencode" : "both");
 		dvr_enabled = 1;
 		osd_publish_bool_fact("dvr.recording", NULL, 0, true);
 		if (dvr_raw) dvr_raw->start_recording();
@@ -644,6 +672,8 @@ extern "C" {
     }
 
     void dvr_start_all(void) {
+        spdlog::info("DVR: starting recording (mode={})",
+                     dvr_mode == DVR_MODE_RAW ? "raw" : dvr_mode == DVR_MODE_REENCODE ? "reencode" : "both");
         dvr_enabled = 1;
         osd_publish_bool_fact("dvr.recording", NULL, 0, true);
         if (dvr_raw) dvr_raw->start_recording();
@@ -652,6 +682,7 @@ extern "C" {
     }
 
     void dvr_stop_all(void) {
+        spdlog::info("DVR: stopping recording");
         if (dvr_raw) dvr_raw->stop_recording();
         if (dvr_reenc_inst) dvr_reenc_inst->stop_recording();
         dvr_enabled = 0;
@@ -1167,6 +1198,9 @@ void printHelp() {
     "\n"
     "    --log-level <level>    - Log verbosity level, debug|info|warn|error (Default: info)\n"
     "\n"
+    "    --log-file <path>      - Also log to <path> (rotated at 1MB, 3 files kept).\n"
+    "                             Use \"none\" to disable file logging. (Default: /var/log/pixelpilot.log)\n"
+    "\n"
     "    --osd                  - Enable OSD\n"
     "\n"
     "    --osd-config <file>    - Path to OSD configuration file\n"
@@ -1246,6 +1280,8 @@ int main(int argc, char **argv)
 	char * config_file_path = NULL;
 	std::string osd_config_path;
 	auto log_level = spdlog::level::info;
+	std::string log_file_path = "/var/log/pixelpilot.log";
+	bool debug_log_pattern = false;
 	
     std::string pidFilePath = "/run/pixelpilot.pid";
     std::ofstream pidFile(pidFilePath);
@@ -1377,7 +1413,7 @@ int main(int argc, char **argv)
 			log_level = spdlog::level::info;
 		} else if (log_l == "debug"){
 			log_level = spdlog::level::debug;
-			spdlog::set_pattern("[%Y-%m-%d %H:%M:%S.%e] [thread %t] [%s:%#] [%^%l%$] %v");
+			debug_log_pattern = true;
 		} else if (log_l == "warn"){
 			log_level = spdlog::level::warn;
 		} else if (log_l == "error"){
@@ -1387,6 +1423,11 @@ int main(int argc, char **argv)
 			printHelp();
 			return -1;
 		}
+		continue;
+	}
+
+	__OnArgument("--log-file") {
+		log_file_path = std::string(__ArgValue);
 		continue;
 	}
 
@@ -1493,7 +1534,42 @@ int main(int argc, char **argv)
 
 	__EndParseConsoleArguments__
 
+	// Give logs a durable home before anything else runs: the console sink
+	// alone is useless once pixelpilot is launched as a backgrounded daemon
+	// (start-stop-daemon -b), since nothing captures stdout in that case --
+	// without a file sink, every spdlog:: call up to now was unrecoverable
+	// for post-hoc field debugging. Keeps the console sink too, so
+	// interactive SSH sessions still see live output.
+	if (!log_file_path.empty() && log_file_path != "none") {
+		try {
+			auto console_sink = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
+			auto file_sink = std::make_shared<spdlog::sinks::rotating_file_sink_mt>(
+				log_file_path, 1 * 1024 * 1024, 3);
+			auto logger = std::make_shared<spdlog::logger>(
+				"pixelpilot", spdlog::sinks_init_list{console_sink, file_sink});
+			spdlog::set_default_logger(logger);
+			// Neither extreme works for a daemon: never flushing means the
+			// handful of lines written right before a crash/kill -- the
+			// exact moment this log exists to capture -- can sit unflushed
+			// forever, while flushing on every call would add I/O on the
+			// FrameProcessor/decoder hot paths, which run on a tight
+			// per-frame microsecond budget. Split it: anything warn or
+			// worse (rare, and precisely the messages likely to precede a
+			// crash) flushes immediately; everything else is flushed by a
+			// lightweight background timer at most every 5s, so routine
+			// info/debug output never lags far behind either.
+			logger->flush_on(spdlog::level::warn);
+			spdlog::flush_every(std::chrono::seconds(5));
+		} catch (const spdlog::spdlog_ex &ex) {
+			spdlog::warn("Could not open log file '{}' ({}); logging to console only",
+			             log_file_path, ex.what());
+		}
+	}
+
 	spdlog::set_level(log_level);
+	if (debug_log_pattern) {
+		spdlog::set_pattern("[%Y-%m-%d %H:%M:%S.%e] [thread %t] [%s:%#] [%^%l%$] %v");
+	}
 	idr_set_enabled(!disable_gregidr);
 
 	if (dvr_template != NULL && (dvr_mode == DVR_MODE_RAW || dvr_mode == DVR_MODE_BOTH) && video_framerate < 0) {
@@ -1649,6 +1725,19 @@ int main(int argc, char **argv)
 		return -2;
 	}
 
+	// One consolidated line describing the session, so a log capturing only
+	// the tail of a long run (or the support-data collector's truncation of
+	// large logs) still tells you what configuration produced it.
+	spdlog::info("PixelPilot {}.{} starting: codec={} display={}x{}@{} dvr-mode={} "
+	             "dvr-reenc-codec={} dvr-reenc-res={} live-colortrans={} log-file={}",
+	             APP_VERSION_MAJOR, APP_VERSION_MINOR,
+	             codec == VideoCodec::H265 ? "h265" : codec == VideoCodec::H264 ? "h264" : "auto",
+	             output_list->mode.hdisplay, output_list->mode.vdisplay, output_list->mode.vrefresh,
+	             dvr_mode == DVR_MODE_RAW ? "raw" : dvr_mode == DVR_MODE_REENCODE ? "reencode" : "both",
+	             reenc_params.codec == VideoCodec::H265 ? "h265" : "h264",
+	             reenc_params.resolution == EncResolution::Res1080p ? "1080p" : "720p",
+	             enable_live_colortrans, log_file_path.empty() ? "none" : log_file_path);
+
 	gamma_lut_controller_init(&lut_ctrl, drm_fd, output_list);
 
 	if (enable_live_colortrans) {
@@ -1758,6 +1847,8 @@ int main(int argc, char **argv)
 		}
 
 		if (dvr_autostart) {
+			spdlog::info("DVR: autostart (--dvr-start) recording (mode={})",
+			             dvr_mode == DVR_MODE_RAW ? "raw" : dvr_mode == DVR_MODE_REENCODE ? "reencode" : "both");
 			dvr_enabled = 1;
 			osd_publish_bool_fact("dvr.recording", NULL, 0, true);
 			if (dvr_raw) dvr_raw->start_recording();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -658,6 +658,28 @@ extern "C" {
         osd_publish_bool_fact("dvr.recording", NULL, 0, false);
     }
 
+    // Called from the FrameProcessor thread the first time a frame can't be
+    // reliably converted (colour-correct/OSD-blend GPU or RGA copy/resize).
+    // Stops only the reencode recording -- raw recording (if DVR_MODE_BOTH)
+    // is a separate, unaffected path and keeps going -- and tells the user
+    // via an OSD popup so they don't think they got a usable recording.
+    void dvr_reenc_on_fatal_error(void) {
+        spdlog::error("DVR reencode: unrecoverable frame conversion failure, stopping recording");
+        if (dvr_reenc_inst) dvr_reenc_inst->stop_recording();
+        osd_publish_str_fact("osd.custom_message", NULL, 0,
+                             "DVR reencode failed\nrecording stopped");
+        // In DVR_MODE_BOTH, raw keeps recording independently and the
+        // indicator should stay on. Otherwise reencode was the only thing
+        // being recorded, so the "recording" indicator must reflect that
+        // nothing is actually being recorded anymore -- leaving it on would
+        // be exactly the misleading state this whole fail-fast design is
+        // meant to avoid.
+        if (dvr_mode != DVR_MODE_BOTH) {
+            dvr_enabled = 0;
+            osd_publish_bool_fact("dvr.recording", NULL, 0, false);
+        }
+    }
+
     /* C-callable wrapper so the menu (C) can set the raw DVR framerate without
      * touching the C++ Dvr* directly. */
     void dvr_set_video_framerate(Dvr* dvr, int f);   /* defined in dvr.cpp */
@@ -754,12 +776,16 @@ extern "C" {
                                  if (dvr_enabled && dvr_reenc_inst) dvr_reenc_inst->frame(nal);
                              });
             pthread_create(&g_tid_enc, NULL, &MppEncoder::__THREAD__, reencoder);
-            frame_proc = new FrameProcessor(reencoder, reenc_params.fps, reenc_params.resolution, drm_fd);
+            frame_proc = new FrameProcessor(reencoder, reenc_params.fps, reenc_params.resolution, drm_fd,
+                                           dvr_reenc_on_fatal_error);
             if (enable_live_colortrans)
                 frame_proc->set_color_correction(live_colortrans_gain,
                                                 live_colortrans_offset, drm_fd);
             pthread_create(&g_tid_fproc, NULL, &FrameProcessor::__THREAD__, frame_proc);
-            dvr_reenc_inst->on_start_cb = []() { if (reencoder) reencoder->request_idr(); };
+            dvr_reenc_inst->on_start_cb = []() {
+                if (reencoder) reencoder->request_idr();
+                if (frame_proc) frame_proc->clear_fatal_error();
+            };
         }
 
         dvr_mode = new_mode;
@@ -1712,7 +1738,8 @@ int main(int argc, char **argv)
 			});
 			ret = pthread_create(&g_tid_enc, NULL, &MppEncoder::__THREAD__, reencoder);
 			assert(!ret);
-			frame_proc = new FrameProcessor(reencoder, reenc_params.fps, reenc_params.resolution, drm_fd);
+			frame_proc = new FrameProcessor(reencoder, reenc_params.fps, reenc_params.resolution, drm_fd,
+			                               dvr_reenc_on_fatal_error);
 			if (enable_live_colortrans) {
 				frame_proc->set_color_correction(live_colortrans_gain,
 				                                live_colortrans_offset, drm_fd);
@@ -1723,6 +1750,7 @@ int main(int argc, char **argv)
 			assert(!ret);
 			dvr_reenc_inst->on_start_cb = []() {
 				if (reencoder) reencoder->request_idr();
+				if (frame_proc) frame_proc->clear_fatal_error();
 			};
 			spdlog::info("Re-encoding recorder: codec={} fps={} bitrate={}kbps",
 			             reenc_params.codec == VideoCodec::H265 ? "h265" : "h264",


### PR DESCRIPTION
DVR reencode: stop silently corrupting recordings, fail fast instead

Investigated a video artifact reported in field footage — DVR reencode frames occasionally skipped colour-correction and showed a green bar at the bottom, while the recording looked completely normal (still "recording", no errors). Root cause: the colour-correct/OSD-blend GL+RGA pipeline had a fallback chain that could publish a corrupted or partially-written frame instead of catching the problem.

Two changes:

Removed the fallback cascade. Any GL/RGA conversion failure now stops the reencode session immediately (raw recording, if also enabled, keeps going untouched) and shows an OSD popup so the user knows recording stopped instead of unknowingly getting a broken file.

Padding guard. Even a successful RGA call could leave the last few rows of the frame buffer unwritten (the bit beyond 1080p's real height, up to the 16-pixel-aligned buffer size) — and this hardware can't reliably let the CPU verify what RGA actually wrote, so detecting it after the fact isn't possible. Instead, we now always extend the last real row into that padding via one more RGA op — guaranteed correct by construction, not by inspection.

This is not a actual fix, at least not for the second bug. We try to guard it and hope it helps.
Will amend this with logging in the sbc-groundstation so the user can generate more useful information.